### PR TITLE
Documentation and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,34 +6,51 @@ A library of useful [Stream Gatherers](https://openjdk.org/jeps/473) (custom int
 
 TBD, once I start publishing snapshots to Maven Central.
 
+# Gatherers In This Library
+
+
+| Function                   | Purpose                                                                                                             |
+|----------------------------|---------------------------------------------------------------------------------------------------------------------|
+| `averageBigDecimals()`     | Create a running or trailing average of `BigDecimal` values. See below for options.                                 |
+| `averageBigDecimalsBy(fn)` | Create a running avergage of `BigDecimal` values mapped out of some different object via `fn`                       |
+| `dedupeConsecutive()`      | Remove conescutive duplicates from a stream |
+| `dedupeConsecutiveBy(fn)`  | Remove consecutive duplicates from a stream as returned by `fn`                                                     |
+| `distinctBy(fn)`           | Emit only distinct elements from the stream, as measured by `fn`                                                    |
+| `interleave(stream)`       | Creates a stream of alternating objects from the input stream and the argument stream                               |
+| `last(n)`                  | Constrain the stream to the last `n` values                                                                         |
+| `withIndex()`              | Maps all elements of the stream as-is, along with their 0-based index.                                              |
+| `zipWith(stream)`          | Creates a stream of `Pair` objects whose values come from the input stream and argument stream                      |
+| `zipWithNext()`            | Creates a stream of `List` objects via a sliding window of width 2 and stepping 1                                   |                          |
+
+
 # Use Cases
 
-(Example, TODO clean this up)
-
-**Running Average**
+#### Running average
 
 ```java
 Stream
-    .of(new BigDecimal("1.0"), new BigDecimal("2.0"), new BigDecimal("10.0"))
+    .of("1.0", "2.0", "10.0")
+    .map(BigDecimal::new)        
     .gather(Gatherers4j.averageBigDecimals())
     .toList();
 
 // [1, 1.5, 4.3333333333333333]
 ```
 
-**Trailing Average**
+#### Moving average
 
 ```java
 Stream
-    .of(new BigDecimal("1.0"), new BigDecimal("2.0"), new BigDecimal("10.0"), new BigDecimal("20.0"), new BigDecimal("30.0"))
-    .gather(Gatherers4j.averageBigDecimals().trailing(2))
+    .of("1.0", "2.0", "10.0", "20.0", "30.0")
+    .map(BigDecimal::new)
+    .gather(Gatherers4j.averageBigDecimals().simpleMovingAverage(2))
     .toList();
 
 // [1.5, 6, 15, 25]
 ```
 
 
-**Removing consecutive duplicate elements:**
+#### Remove consecutive duplicate elements
 
 ```java
 Stream
@@ -44,7 +61,52 @@ Stream
 // ["A", "B", "C", "D", "A", "B", "C"]
 ```
 
-**Limit the stream to the `last` _n_ elements:**
+#### Remove consecutive duplicate elements, where duplicate is measured by a function
+
+```java
+record Person(String firstName, String lastName) {}
+
+Stream
+    .of(
+        new Person("Todd", "Ginsberg"),
+        new Person("Emma", "Ginsberg"),
+        new Person("Todd", "Smith")
+    )
+    .gather(Gatherers4j.dedupeConsecutiveBy(Person::firstName))
+    .toList();
+
+// [Person("Todd", "Ginsberg"), Person("Todd", "Smith")]
+```
+
+#### Remove duplicate elements, where duplicate is measured by a function
+
+```java
+record Person(String firstName, String lastName) {}
+
+Stream
+    .of(
+        new Person("Todd", "Ginsberg"),
+        new Person("Emma", "Ginsberg"),
+        new Person("Todd", "Smith")
+    )
+    .gather(Gatherers4j.distinctBy(Person::firstName))
+    .toList();
+
+// [Person("Todd", "Ginsberg"), Person("Emma", "Ginsberg")]
+```
+
+#### Interleave streams of the same type into one stream
+
+```java
+final Stream<String> left = Stream.of("A", "B", "C");
+final Stream<String> right = Stream.of("D", "E", "F");
+
+left.gather(Gatherers4j.interleave(right)).toList();
+
+// ["A", "D", "B", "E", "C", "F"]
+```
+
+#### Limit the stream to the `last` _n_ elements
 
 ```java
 Stream
@@ -55,8 +117,53 @@ Stream
 // ["E", "F", "G"]
 ```
 
+#### Include index with original stream values
+
+```java
+Stream
+    .of("A", "B", "C")
+    .gather(Gatherers4j.withIndex())
+    .toList();
+
+// [IndexedValue(0, "A"), IndexedValue(1, "B"), IndexedValue(2, "C")]
+```
+
+#### Zip two streams of together into a `Stream<Pair>`
+
+The left and right streams can be of different types.
+
+```java
+final Stream<String> left = Stream.of("A", "B", "C");
+final Stream<Integer> right = Stream.of(1, 2, 3);
+
+left.gather(Gatherers4j.zip(right)).toList();
+
+// [Pair("A", 1), Pair("B", 2), Pair("C", 3)] 
+
+```
+
+#### Zip elements of a stream together
+
+This converts a `Stream<T>` to a `Stream<List<T>>`
+
+```java
+Stream
+     .of("A", "B", "C", "D", "E")
+     .gather(Gatherers4j.zipWitNext())
+     .toList();
+
+// [["A", "B"], ["B", "C"], ["C", "D"], ["D", "E"]]
+```
+
+
+# Project Philosophy
+
+1. Consider adding a gatherer if it cannot be implemented with `map`, `filter`, or a collector without enclosing outside state.
+2. Resist the temptation to add functions that only exist to provide an alias. They seem fun/handy but add surface area to the API and must be maintained forever.
+3. All features should be documented and tested.
+
 # Contributing
 
-Guidance forthcoming.
+Please feel free to file issues for change requests or bugs. If you would like to contribute new functionality, please contact me before starting work!
 
 Copyright © 2024 by Todd Ginsberg

--- a/src/main/java/com/ginsberg/gatherers4j/GathererUtils.java
+++ b/src/main/java/com/ginsberg/gatherers4j/GathererUtils.java
@@ -17,7 +17,7 @@ package com.ginsberg.gatherers4j;
 
 public class GathererUtils {
 
-    public static boolean safeEquals(final Object left, final Object right) {
+    static boolean safeEquals(final Object left, final Object right) {
         if (left == null && right == null) {
             return true;
         } else if (left == null || right == null) {
@@ -26,7 +26,7 @@ public class GathererUtils {
         return left.equals(right);
     }
 
-    public static void mustNotBeNull(final Object subject, final String message) {
+    static void mustNotBeNull(final Object subject, final String message) {
         if (subject == null) {
             throw new IllegalArgumentException(message);
         }

--- a/src/main/java/com/ginsberg/gatherers4j/Gatherers4j.java
+++ b/src/main/java/com/ginsberg/gatherers4j/Gatherers4j.java
@@ -18,10 +18,11 @@ package com.ginsberg.gatherers4j;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Gatherer;
 import java.util.stream.Stream;
+
+import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
 
 public class Gatherers4j {
 
@@ -61,23 +62,30 @@ public class Gatherers4j {
     }
 
     /**
+     * Remove consecutive duplicates from a stream where duplication is measured by the given <code>function</code>.
+     *
      * @param function A mapping function used to compare objects in the stream for equality.
      */
     public static <INPUT> Gatherer<INPUT, ?, INPUT> dedupeConsecutiveBy(final Function<INPUT, Object> function) {
-        Objects.requireNonNull(function, "Mapping function cannot be null");
+        mustNotBeNull(function, "Mapping function cannot be null");
         return new DedupeConsecutiveGatherer<>(function);
     }
 
     /**
-     * Filter a stream to only distinct elements as described by the given function.
+     * Filter a stream to only distinct elements as described by the given <code>function</code>.
      *
-     * @param function The mapping function
+     * @param function The non-null mapping function
      */
     public static <INPUT, OUTPUT> Gatherer<INPUT, ?, INPUT> distinctBy(final Function<INPUT, OUTPUT> function) {
-        Objects.requireNonNull(function, "Mapping function cannot be null"); // TODO: Where should this go?
+        mustNotBeNull(function, "Mapping function cannot be null");
         return new DistinctGatherer<>(function);
     }
 
+    /**
+     * Creates a stream of alternating objects from the input stream and the argument stream
+     *
+     * @param other A non-null stream to interleave
+     */
     public static <INPUT> Gatherer<INPUT, Void, INPUT> interleave(final Stream<INPUT> other) {
         return new InterleavingGatherer<>(other);
     }
@@ -91,19 +99,25 @@ public class Gatherers4j {
         return new LastGatherer<>(count);
     }
 
-    public static <INPUT, OUTPUT> Gatherer<INPUT, ?, IndexedValue<OUTPUT>> mapWithIndex(final Function<INPUT, OUTPUT> mappingFunction) {
-        Objects.requireNonNull(mappingFunction, "Mapping function cannot be null");
-        return new IndexingGatherer<>(mappingFunction);
-    }
-
+    /**
+     * Maps all elements of the stream as-is, along with their 0-based index.
+     */
     public static <INPUT> Gatherer<INPUT, ?, IndexedValue<INPUT>> withIndex() {
-        return new IndexingGatherer<>(Function.identity());
+        return new IndexingGatherer<>();
     }
 
-    public static <FIRST, SECOND> Gatherer<FIRST, Void, Pair<FIRST, SECOND>> zip(final Stream<SECOND> other) {
-        return new ZipGatherer<>(other);
+    /**
+     * Creates a stream of `Pair` objects whose values come from the input stream and argument stream
+     *
+     * @param other A non-null stream to zip with
+     */
+    public static <FIRST, SECOND> Gatherer<FIRST, Void, Pair<FIRST, SECOND>> zipWith(final Stream<SECOND> other) {
+        return new ZipWithGatherer<>(other);
     }
 
+    /**
+     * Creates a stream of `List` objects via a sliding window of width 2 and stepping 1
+     */
     public static <INPUT> Gatherer<INPUT, ?, List<INPUT>> zipWithNext() {
         return new ZipWithNextGatherer<>();
     }

--- a/src/main/java/com/ginsberg/gatherers4j/IndexingGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/IndexingGatherer.java
@@ -16,17 +16,13 @@
 
 package com.ginsberg.gatherers4j;
 
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Gatherer;
 
-public class IndexingGatherer<INPUT, OUTPUT>
-        implements Gatherer<INPUT, IndexingGatherer.State, IndexedValue<OUTPUT>> {
+public class IndexingGatherer<INPUT>
+        implements Gatherer<INPUT, IndexingGatherer.State, IndexedValue<INPUT>> {
 
-    private final Function<INPUT, OUTPUT> mappingFunction;
-
-    IndexingGatherer(final Function<INPUT, OUTPUT> function) {
-        this.mappingFunction = function;
+    IndexingGatherer() {
     }
 
     @Override
@@ -35,9 +31,9 @@ public class IndexingGatherer<INPUT, OUTPUT>
     }
 
     @Override
-    public Integrator<IndexingGatherer.State, INPUT, IndexedValue<OUTPUT>> integrator() {
+    public Integrator<IndexingGatherer.State, INPUT, IndexedValue<INPUT>> integrator() {
         return (state, element, downstream) -> downstream
-                .push(new IndexedValue<>(state.index++, mappingFunction.apply(element)));
+                .push(new IndexedValue<>(state.index++, element));
     }
 
     public static class State {

--- a/src/main/java/com/ginsberg/gatherers4j/ZipWithGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/ZipWithGatherer.java
@@ -21,10 +21,10 @@ import java.util.Spliterator;
 import java.util.stream.Gatherer;
 import java.util.stream.Stream;
 
-public class ZipGatherer<FIRST, SECOND> implements Gatherer<FIRST, Void, Pair<FIRST, SECOND>> {
+public class ZipWithGatherer<FIRST, SECOND> implements Gatherer<FIRST, Void, Pair<FIRST, SECOND>> {
     private final Spliterator<SECOND> otherSpliterator;
 
-    ZipGatherer(final Stream<SECOND> other) {
+    ZipWithGatherer(final Stream<SECOND> other) {
         Objects.requireNonNull(other, "Other stream must not be null");
         otherSpliterator = other.spliterator();
     }

--- a/src/test/java/com/ginsberg/gatherers4j/AveragingBigDecimalGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/AveragingBigDecimalGathererTest.java
@@ -185,7 +185,7 @@ class AveragingBigDecimalGathererTest {
     }
 
     @Test
-    void trailingAverageOfBigDecimals() {
+    void simpleMovingAverageAverageOfBigDecimals() {
         // Arrange
         final Stream<BigDecimal> input = Stream.of(
                 new BigDecimal("1.0"),
@@ -197,7 +197,7 @@ class AveragingBigDecimalGathererTest {
 
         // Act
         final List<BigDecimal> output = input
-                .gather(Gatherers4j.averageBigDecimals().trailing(2))
+                .gather(Gatherers4j.averageBigDecimals().simpleMovingAverage(2))
                 .toList();
 
         // Assert
@@ -212,7 +212,7 @@ class AveragingBigDecimalGathererTest {
     }
 
     @Test
-    void trailingAverageOfBigDecimalsWithPartials() {
+    void simpleMovingAverageAverageOfBigDecimalsWithPartials() {
         // Arrange
         final Stream<BigDecimal> input = Stream.of(
                 new BigDecimal("1.0"),
@@ -224,7 +224,7 @@ class AveragingBigDecimalGathererTest {
 
         // Act
         final List<BigDecimal> output = input
-                .gather(Gatherers4j.averageBigDecimals().trailing(2).includePartialTailingValues())
+                .gather(Gatherers4j.averageBigDecimals().simpleMovingAverage(2).includePartialValues())
                 .toList();
 
         // Assert
@@ -355,16 +355,16 @@ class AveragingBigDecimalGathererTest {
     }
 
     @Test
-    void trailingInvalidRangeZero() {
+    void simpleMovingAverageInvalidRangeZero() {
         assertThatThrownBy(() ->
-                Stream.of(BigDecimal.ONE).gather(Gatherers4j.averageBigDecimals().trailing(0))
+                Stream.of(BigDecimal.ONE).gather(Gatherers4j.averageBigDecimals().simpleMovingAverage(0))
         ).isExactlyInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    void trailingInvalidRangeNegative() {
+    void simpleMovingAverageInvalidRangeNegative() {
         assertThatThrownBy(() ->
-                Stream.of(BigDecimal.ONE).gather(Gatherers4j.averageBigDecimals().trailing(-1))
+                Stream.of(BigDecimal.ONE).gather(Gatherers4j.averageBigDecimals().simpleMovingAverage(-1))
         ).isExactlyInstanceOf(IllegalArgumentException.class);
     }
 

--- a/src/test/java/com/ginsberg/gatherers4j/DedupeConsecutiveGatherersTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/DedupeConsecutiveGatherersTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class DedupeConsecutiveGatherersTest {
 
@@ -89,5 +90,16 @@ class DedupeConsecutiveGatherersTest {
                 new TestConsecutive(4, "B"),
                 new TestConsecutive(6, "C")
         );
+    }
+
+
+    @Test
+    void dedupeConsecutiveByWithNullMappingFunction() {
+        // Arrange
+        final Stream<String> input = Stream.of("A");
+
+        // Act/Assert
+        assertThatThrownBy(() -> input.gather(Gatherers4j.dedupeConsecutiveBy(null)).toList())
+                .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/com/ginsberg/gatherers4j/DistinctGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/DistinctGathererTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class DistinctGathererTest {
 
@@ -51,5 +52,15 @@ class DistinctGathererTest {
 
         // Assert
         assertThat(output).containsExactly(null, "a");
+    }
+
+    @Test
+    void distinctByWithNullMappingFunction() {
+        // Arrange
+        final Stream<String> input = Stream.of("A");
+
+        // Act/Assert
+        assertThatThrownBy(() -> input.gather(Gatherers4j.distinctBy(null)).toList())
+                .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/com/ginsberg/gatherers4j/IndexingGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/IndexingGathererTest.java
@@ -16,7 +16,6 @@
 
 package com.ginsberg.gatherers4j;
 
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -26,105 +25,42 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class IndexingGathererTest {
 
-    @Nested
-    class MapWithIndex {
-        @Test
-        void mapObjectWithIndex() {
-            // Arrange
-            final Stream<String> input = Stream.of("A", "B", "C");
+    @Test
+    void objectWithIndex() {
+        // Arrange
+        final Stream<String> input = Stream.of("A", "B", "C");
 
-            // Act
-            final List<IndexedValue<String>> output = input
-                    .gather(Gatherers4j.mapWithIndex(String::toLowerCase))
-                    .toList();
+        // Act
+        final List<IndexedValue<String>> output = input
+                .gather(Gatherers4j.withIndex())
+                .toList();
 
-            // Assert
-            assertThat(output)
-                    .containsExactly(
-                            new IndexedValue<>(0, "a"),
-                            new IndexedValue<>(1, "b"),
-                            new IndexedValue<>(2, "c")
-                    );
-        }
-
-        @Test
-        void mapIntegerWithIndex() {
-            // Arrange
-            final Stream<Integer> input = Stream.of(1, 2, 3);
-
-            // Act
-            final List<IndexedValue<Integer>> output = input
-                    .gather(Gatherers4j.mapWithIndex(it -> it * it))
-                    .toList();
-
-            // Assert
-            assertThat(output)
-                    .containsExactly(
-                            new IndexedValue<>(0, 1),
-                            new IndexedValue<>(1, 4),
-                            new IndexedValue<>(2, 9)
-                    );
-        }
-
-        @Test
-        void mapIntegerToStringWithIndex() {
-            // Arrange
-            final Stream<Integer> input = Stream.of(1, 2, 3);
-
-            // Act
-            final List<IndexedValue<String>> output = input
-                    .gather(Gatherers4j.mapWithIndex(it -> String.valueOf(it * it)))
-                    .toList();
-
-            // Assert
-            assertThat(output)
-                    .containsExactly(
-                            new IndexedValue<>(0, "1"),
-                            new IndexedValue<>(1, "4"),
-                            new IndexedValue<>(2, "9")
-                    );
-        }
+        // Assert
+        assertThat(output)
+                .containsExactly(
+                        new IndexedValue<>(0, "A"),
+                        new IndexedValue<>(1, "B"),
+                        new IndexedValue<>(2, "C")
+                );
     }
 
-    @Nested
-    class WithIndex {
-        @Test
-        void objectWithIndex() {
-            // Arrange
-            final Stream<String> input = Stream.of("A", "B", "C");
+    @Test
+    void integerWithIndex() {
+        // Arrange
+        final Stream<Integer> input = Stream.of(1, 2, 3);
 
-            // Act
-            final List<IndexedValue<String>> output = input
-                    .gather(Gatherers4j.withIndex())
-                    .toList();
+        // Act
+        final List<IndexedValue<Integer>> output = input
+                .gather(Gatherers4j.withIndex())
+                .toList();
 
-            // Assert
-            assertThat(output)
-                    .containsExactly(
-                            new IndexedValue<>(0, "A"),
-                            new IndexedValue<>(1, "B"),
-                            new IndexedValue<>(2, "C")
-                    );
-        }
-
-        @Test
-        void integerWithIndex() {
-            // Arrange
-            final Stream<Integer> input = Stream.of(1, 2, 3);
-
-            // Act
-            final List<IndexedValue<Integer>> output = input
-                    .gather(Gatherers4j.withIndex())
-                    .toList();
-
-            // Assert
-            assertThat(output)
-                    .containsExactly(
-                            new IndexedValue<>(0, 1),
-                            new IndexedValue<>(1, 2),
-                            new IndexedValue<>(2, 3)
-                    );
-        }
+        // Assert
+        assertThat(output)
+                .containsExactly(
+                        new IndexedValue<>(0, 1),
+                        new IndexedValue<>(1, 2),
+                        new IndexedValue<>(2, 3)
+                );
     }
 
 }

--- a/src/test/java/com/ginsberg/gatherers4j/ZipWithGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/ZipWithGathererTest.java
@@ -23,7 +23,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ZipGathererTest {
+class ZipWithGathererTest {
 
     @Test
     void zipGatherer() {
@@ -33,7 +33,7 @@ class ZipGathererTest {
 
         // Act
         final List<Pair<String, Integer>> output = left
-                .gather(Gatherers4j.zip(right))
+                .gather(Gatherers4j.zipWith(right))
                 .toList();
 
         // Assert
@@ -53,7 +53,7 @@ class ZipGathererTest {
 
         // Act
         final List<Pair<String, Integer>> output = left
-                .gather(Gatherers4j.zip(right))
+                .gather(Gatherers4j.zipWith(right))
                 .toList();
 
         // Assert
@@ -68,7 +68,7 @@ class ZipGathererTest {
 
         // Act
         final List<Pair<String, Integer>> output = left
-                .gather(Gatherers4j.zip(right))
+                .gather(Gatherers4j.zipWith(right))
                 .toList();
 
         // Assert


### PR DESCRIPTION
+ Documenting usages in README
+ JavaDocs for user-facing functions
+ Move util functions to package
+ Rename `zip` to `zipWith`
+ Remove `mapWithIndex`, not useful (use `map`)
+ Added test cases for null parameters
+ Changed argument-related `NullPointerException` to `IllegalArgumentException`