### PR TITLE
Implement geedy integrators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 0.7.0
-+ TBD
++ Use greedy integrators where possible (Fixes #57)
 
 ### 0.6.0
 + Implement `dropLast(n)`

--- a/src/main/java/com/ginsberg/gatherers4j/BigDecimalGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/BigDecimalGatherer.java
@@ -36,7 +36,7 @@ abstract public class BigDecimalGatherer<INPUT>
 
     @Override
     public Integrator<BigDecimalGatherer.State, INPUT, BigDecimal> integrator() {
-        return (state, element, downstream) -> {
+        return Integrator.ofGreedy((state, element, downstream) -> {
             final BigDecimal mappedElement = element == null ? nullReplacement : mappingFunction.apply(element);
             if (mappedElement != null) {
                 state.add(mappedElement, mathContext);
@@ -45,7 +45,7 @@ abstract public class BigDecimalGatherer<INPUT>
                 }
             }
             return !downstream.isRejecting();
-        };
+        });
     }
 
     /// When encountering a `null` value in a stream, treat it as `BigDecimal.ZERO` instead.

--- a/src/main/java/com/ginsberg/gatherers4j/DedupeConsecutiveGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/DedupeConsecutiveGatherer.java
@@ -37,7 +37,7 @@ public class DedupeConsecutiveGatherer<INPUT>
 
     @Override
     public Integrator<DedupeConsecutiveGatherer.State, INPUT, INPUT> integrator() {
-        return (state, element, downstream) -> {
+        return Integrator.ofGreedy((state, element, downstream) -> {
             final Object mapped = mappingFunction == null ? element : mappingFunction.apply(element);
             if (!state.hasValue) {
                 state.hasValue = true;
@@ -48,7 +48,7 @@ public class DedupeConsecutiveGatherer<INPUT>
                 return downstream.push(element);
             }
             return !downstream.isRejecting();
-        };
+        });
     }
 
     public static class State {

--- a/src/main/java/com/ginsberg/gatherers4j/DistinctGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/DistinctGatherer.java
@@ -40,12 +40,12 @@ public class DistinctGatherer<INPUT>
 
     @Override
     public Integrator<DistinctGatherer.State, INPUT, INPUT> integrator() {
-        return (state, element, downstream) -> {
+        return Integrator.ofGreedy((state, element, downstream) -> {
             if (state.knownObjects.add(byFunction.apply(element))) {
                 downstream.push(element);
             }
             return !downstream.isRejecting();
-        };
+        });
     }
 
     public static class State {

--- a/src/main/java/com/ginsberg/gatherers4j/DropLastGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/DropLastGatherer.java
@@ -40,10 +40,10 @@ public class DropLastGatherer<INPUT> implements Gatherer<INPUT, DropLastGatherer
 
     @Override
     public Integrator<State<INPUT>, INPUT, INPUT> integrator() {
-        return (state, element, downstream) -> {
+        return Integrator.ofGreedy((state, element, downstream) -> {
             state.elements.add(element);
             return !downstream.isRejecting();
-        };
+        });
     }
 
     @Override

--- a/src/main/java/com/ginsberg/gatherers4j/FilteringWithIndexGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/FilteringWithIndexGatherer.java
@@ -39,12 +39,12 @@ public class FilteringWithIndexGatherer<INPUT>
 
     @Override
     public Integrator<FilteringWithIndexGatherer.State, INPUT, INPUT> integrator() {
-        return (state, element, downstream) -> {
+        return Integrator.ofGreedy((state, element, downstream) -> {
             if (predicate.test(state.index++, element)) {
                 downstream.push(element);
             }
             return !downstream.isRejecting();
-        };
+        });
     }
 
     public static class State {

--- a/src/main/java/com/ginsberg/gatherers4j/IndexingGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/IndexingGatherer.java
@@ -32,7 +32,9 @@ public class IndexingGatherer<INPUT>
 
     @Override
     public Integrator<IndexingGatherer.State, INPUT, IndexedValue<INPUT>> integrator() {
-        return (state, element, downstream) -> downstream.push(new IndexedValue<>(state.index++, element));
+        return Integrator.ofGreedy((state, element, downstream) ->
+                downstream.push(new IndexedValue<>(state.index++, element))
+        );
     }
 
     public static class State {

--- a/src/main/java/com/ginsberg/gatherers4j/LastGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/LastGatherer.java
@@ -51,12 +51,12 @@ public class LastGatherer<INPUT> implements Gatherer<INPUT, LastGatherer.State<I
 
     @Override
     public Integrator<State<INPUT>, INPUT, INPUT> integrator() {
-        return Integrator.ofGreedy((state, element, _) -> {
+        return Integrator.ofGreedy((state, element, downstream) -> {
             if (state.elements.size() == lastCount) {
                 state.elements.removeFirst();
             }
             state.elements.add(element);
-            return true;
+            return !downstream.isRejecting();
         });
     }
 

--- a/src/main/java/com/ginsberg/gatherers4j/MinMaxGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/MinMaxGatherer.java
@@ -39,7 +39,7 @@ public class MinMaxGatherer<INPUT, MAPPED extends Comparable<MAPPED>>
 
     @Override
     public Integrator<State<INPUT, MAPPED>, INPUT, INPUT> integrator() {
-        return (state, element, downstream) -> {
+        return Integrator.ofGreedy((state, element, downstream) -> {
             final MAPPED mapped = element == null ? null : mappingFunction.apply(element);
             if (mapped == null) {
                 return !downstream.isRejecting();
@@ -55,7 +55,7 @@ public class MinMaxGatherer<INPUT, MAPPED extends Comparable<MAPPED>>
                 }
             }
             return !downstream.isRejecting();
-        };
+        });
     }
 
     @Override

--- a/src/main/java/com/ginsberg/gatherers4j/ReversingGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/ReversingGatherer.java
@@ -31,7 +31,10 @@ public class ReversingGatherer<INPUT> implements Gatherer<INPUT, ReversingGather
 
     @Override
     public Integrator<State<INPUT>, INPUT, INPUT> integrator() {
-        return (state, element, _) -> state.inputs.add(element);
+        return Integrator.ofGreedy((state, element, downstream) -> {
+            state.inputs.add(element);
+            return !downstream.isRejecting();
+        });
     }
 
     @Override

--- a/src/main/java/com/ginsberg/gatherers4j/ShufflingGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/ShufflingGatherer.java
@@ -41,7 +41,10 @@ public class ShufflingGatherer<INPUT> implements Gatherer<INPUT, ShufflingGather
 
     @Override
     public Integrator<ShufflingGatherer.State<INPUT>, INPUT, INPUT> integrator() {
-        return (state, element, _) -> state.inputs.add(element);
+        return Integrator.ofGreedy((state, element, downstream) -> {
+            state.inputs.add(element);
+            return !downstream.isRejecting();
+        });
     }
 
     @Override

--- a/src/main/java/com/ginsberg/gatherers4j/ThrottlingGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/ThrottlingGatherer.java
@@ -63,12 +63,12 @@ public class ThrottlingGatherer<INPUT> implements Gatherer<INPUT, ThrottlingGath
 
     @Override
     public Integrator<State, INPUT, INPUT> integrator() {
-        return (state, element, downstream) -> {
+        return Integrator.ofGreedy((state, element, downstream) -> {
             if (!downstream.isRejecting() && state.attempt()) {
                 downstream.push(element);
             }
             return !downstream.isRejecting();
-        };
+        });
     }
 
     public static class State {

--- a/src/main/java/com/ginsberg/gatherers4j/ZipWithGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/ZipWithGatherer.java
@@ -106,9 +106,9 @@ public class ZipWithGatherer<FIRST, SECOND> implements Gatherer<FIRST, Void, Pai
         return (_, element, downstream) -> {
             boolean advanced = otherSpliterator.tryAdvance(it -> downstream.push(new Pair<>(element, it)));
             if (!advanced && argumentWhenSourceLonger != null) {
-                downstream.push(new Pair<>(element, argumentWhenSourceLonger.apply(element)));
+                return downstream.push(new Pair<>(element, argumentWhenSourceLonger.apply(element)));
             }
-            return !downstream.isRejecting();
+            return advanced && !downstream.isRejecting();
         };
     }
 

--- a/src/main/java/com/ginsberg/gatherers4j/ZipWithNextGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/ZipWithNextGatherer.java
@@ -33,7 +33,7 @@ public class ZipWithNextGatherer<INPUT> implements Gatherer<INPUT, ZipWithNextGa
 
     @Override
     public Integrator<State<INPUT>, INPUT, List<INPUT>> integrator() {
-        return (state, element, downstream) -> {
+        return Integrator.ofGreedy((state, element, downstream) -> {
             if (!state.hasValue) {
                 state.hasValue = true;
             } else {
@@ -41,7 +41,7 @@ public class ZipWithNextGatherer<INPUT> implements Gatherer<INPUT, ZipWithNextGa
             }
             state.value = element;
             return !downstream.isRejecting();
-        };
+        });
 
     }
 


### PR DESCRIPTION
+ Greedy integrators can be used anywhere the integrator does not itself initiate a short circuit (returns false). Passing along the downstream rejecting flag is allowed for greedy integrators.