### PR TITLE
Broader support for stream sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 + Implement `orderByFrequencyAscending()` and `orderByFrequencyDescending()`
 + Implement `movingProduct()` and `movingProductBy()`
 + Implement `movingSum()` and `movingSumBy()`
-+ Functions, when used as arguments, should come last for consistency and to play nice with Kotlin (Fixes #64)
 + Remove `maxBy(fn)` and `minBy(fn)`, can be done with JDK methods trivially
++ Rename `exactSize()` to `sizeExactly()`
++ Implement `sizeLessThan`, `sizeLessThanOrEqualTo`, `sizeGreaterThan`, and `sizeGreaterThanOrEqualTo`
++ API Style - Functions, when used as arguments, should come last for consistency and to play nice with Kotlin (Fixes #64)
 
 ### 0.6.0
 + Implement `dropLast(n)`

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ implementation("com.ginsberg:gatherers4j:0.7.0")
 | `dedupeConsecutiveBy(fn)`     | Remove consecutive duplicates from a stream as returned by `fn`                                                                |
 | `distinctBy(fn)`              | Emit only distinct elements from the stream, as measured by `fn`                                                               |
 | `dropLast(n)`                 | Keep all but the last `n` elements of the stream                                                                               |
-| `exactSize(n)`                | Ensure the stream is exactly `n` elements long, or throw an `IllegalStateException`                                            |
 | `filterWithIndex(predicate)`  | Filter the stream with the given `predicate`, which takes an `element` and its `index`                                         |
 | `grouping()`                  | Group consecute identical elements into lists                                                                                  |
 | `groupingBy(fn)`              | Group consecutive elements that are identical according to `fn` into lists                                                     |                                                                                                                    
@@ -51,6 +50,11 @@ implementation("com.ginsberg:gatherers4j:0.7.0")
 | `reverse()`                   | Reverse the order of the stream                                                                                                |
 | `shuffle()`                   | Shuffle the stream into a random order using the platform default `RandomGenerator`                                            |
 | `shuffle(rg)`                 | Shuffle the stream into a random order using the specified `RandomGenerator`                                                   |
+| `sizeExactly(n)`              | Ensure the stream is exactly `n` elements long, or throw an `IllegalStateException`                                            |
+| `sizeGreaterThan(n)`          | Ensure the stream is greater than `n` elements long, or throw an `IllegalStateException`                                       |
+| `sizeGreaterThanOrEqualTo(n)` | Ensure the stream is greater than or equal to `n` elements long, or throw an `IllegalStateException`                           |
+| `sizeLessThan(n)`             | Ensure the stream is less than `n` elements long, or throw an `IllegalStateException`                                          |
+| `sizeLessThanOrEqualTo(n)`    | Ensure the stream is less than or equal to `n` elements long, or throw an `IllegalStateException`                              |
 | `throttle(amount, duration)`  | Limit stream elements to `amount` elements over `duration`, pausing until a new `duration` period starts                       |
 | `withIndex()`                 | Maps all elements of the stream as-is along with their 0-based index                                                           |
 | `zipWith(iterable)`           | Creates a stream of `Pair` objects whose values come from the input stream and argument iterable                               |
@@ -165,11 +169,64 @@ Stream.of("A", "B", "C", "D", "E")
 ```java
 // Good
 
-Stream.of("A", "B", "C").gather(Gatherers4j.exactSize(3)).toList();
+Stream.of("A", "B", "C").gather(Gatherers4j.sizeExactly(3)).toList();
 // ["A", "B", "C"]
 
 // Bad
-Stream.of("A").gather(Gatherers4j.exactSize(3)).toList();
+Stream.of("A").gather(Gatherers4j.sizeExactly(3)).toList();
+// IllegalStateException
+```
+
+#### Ensure the stream is greater than `n` elements long
+
+```java
+// Good
+
+Stream.of("A", "B", "C").gather(Gatherers4j.sizeGreaterThan(2)).toList();
+// ["A", "B", "C"]
+
+// Bad
+Stream.of("A", "B").gather(Gatherers4j.sizeGreaterThan(2)).toList();
+// IllegalStateException
+```
+
+#### Ensure the stream is greater than or equal to `n` elements long
+
+```java
+// Good
+
+Stream.of("A", "B").gather(Gatherers4j.sizeGreaterThanOrEqualTo(2)).toList();
+// ["A", "B"]
+
+// Bad
+Stream.of("A").gather(Gatherers4j.sizeGreaterThanOrEqualTo(2)).toList();
+// IllegalStateException
+```
+
+#### Ensure the stream is less than `n` elements long
+
+```java
+// Good
+
+Stream.of("A").gather(Gatherers4j.sizeLessThan(2)).toList();
+// ["A"]
+
+// Bad
+Stream.of("A", "B").gather(Gatherers4j.sizeLessThan(2)).toList();
+// IllegalStateException
+```
+
+
+#### Ensure the stream is less than or equal to `n` elements long
+
+```java
+// Good
+
+Stream.of("A", "B").gather(Gatherers4j.sizeLessThanOrEqualTo(2)).toList();
+// ["A", "B"]
+
+// Bad
+Stream.of("A", "B", "C").gather(Gatherers4j.sizeLessThanOrEqualTo(2)).toList();
 // IllegalStateException
 ```
 

--- a/src/main/java/com/ginsberg/gatherers4j/Gatherers4j.java
+++ b/src/main/java/com/ginsberg/gatherers4j/Gatherers4j.java
@@ -86,22 +86,11 @@ public abstract class Gatherers4j {
         return new DropLastGatherer<>(count);
     }
 
-    /// Ensure the input stream is exactly `size` elements long, and emit all elements if so.
-    /// If not, throw an `IllegalStateException`.
-    ///
-    /// @param size    Exact number of elements the stream must have
-    /// @param <INPUT> Type of elements in both the input and output streams
-    /// @return A non-null `SizeGatherer`
-    /// @throws IllegalStateException when the input stream is not exactly `size` elements long
-    public static <INPUT extends @Nullable Object> SizeGatherer<INPUT> exactSize(final long size) {
-        return new SizeGatherer<>(size);
-    }
-
     /// Filter a stream according to the given `predicate`, which takes both the item being examined,
     /// and its index.
     ///
     /// @param predicate A non-null `BiPredicate<Long,INPUT>` where the `Long` is the zero-based index of the element
-    ///                                                    being filtered, and the `INPUT` is the element itself.
+    ///                                                                     being filtered, and the `INPUT` is the element itself.
     /// @param <INPUT>   Type of elements in the input stream
     /// @return A non-null `FilteringWithIndexGatherer`
     public static <INPUT extends @Nullable Object> FilteringWithIndexGatherer<INPUT> filterWithIndex(
@@ -181,7 +170,7 @@ public abstract class Gatherers4j {
     ///
     /// @param windowSize      The trailing number of elements to multiply, must be greater than 1.
     /// @param mappingFunction A function to map `<INPUT>` objects to `BigDecimal`, the results of which will be used
-    ///                        in the moving product calculation
+    ///                                               in the moving product calculation
     /// @param <INPUT>         Type of elements in the input stream, to be remapped to `BigDecimal` by the `mappingFunction`
     /// @return A non-null `BigDecimalMovingProductGatherer`
     public static <INPUT extends @Nullable Object> BigDecimalMovingProductGatherer<INPUT> movingProductBy(
@@ -205,7 +194,7 @@ public abstract class Gatherers4j {
     ///
     /// @param windowSize      The trailing number of elements to multiply, must be greater than 1.
     /// @param mappingFunction A function to map `<INPUT>` objects to `BigDecimal`, the results of which will be used
-    ///                        in the moving sum calculation
+    ///                                               in the moving sum calculation
     /// @param <INPUT>         Type of elements in the input stream, to be remapped to `BigDecimal` by the `mappingFunction`
     /// @return A non-null `BigDecimalMovingSumGatherer`
     public static <INPUT extends @Nullable Object> BigDecimalMovingSumGatherer<INPUT> movingSumBy(
@@ -287,7 +276,7 @@ public abstract class Gatherers4j {
     /// objects mapped from a `Stream<BigDecimal>` via a `mappingFunction`.
     ///
     /// @param mappingFunction A function to map `<INPUT>` objects to `BigDecimal`, the results of which will be used
-    ///                                                                      in the standard deviation calculation
+    ///                                                                                             in the standard deviation calculation
     /// @param <INPUT>         Type of elements in the input stream, to be remapped to `BigDecimal` by the `mappingFunction`
     /// @return A non-null `BigDecimalStandardDeviationGatherer`
     public static <INPUT extends @Nullable Object> BigDecimalStandardDeviationGatherer<INPUT> runningPopulationStandardDeviationBy(
@@ -310,7 +299,7 @@ public abstract class Gatherers4j {
     /// from a `Stream<INPUT>` via a `mappingFunction`.
     ///
     /// @param mappingFunction A function to map `<INPUT>` objects to `BigDecimal`, the results of which will be used
-    ///                                                                      in the product calculation
+    ///                                                                                             in the product calculation
     /// @param <INPUT>         Type of elements in the input stream, to be remapped to `BigDecimal` by the `mappingFunction`
     /// @return A non-null `BigDecimalProductGatherer`
     public static <INPUT extends @Nullable Object> BigDecimalProductGatherer<INPUT> runningProductBy(
@@ -333,7 +322,7 @@ public abstract class Gatherers4j {
     /// from a `Stream<INPUT>` via a `mappingFunction`.
     ///
     /// @param mappingFunction A function to map `<INPUT>` objects to `BigDecimal`, the results of which will be used
-    ///                                                                      in the standard deviation calculation
+    ///                                                                                             in the standard deviation calculation
     /// @param <INPUT>         Type of elements in the input stream, to be remapped to `BigDecimal` by the `mappingFunction`
     /// @return A non-null `BigDecimalStandardDeviationGatherer`
     public static <INPUT extends @Nullable Object> BigDecimalStandardDeviationGatherer<INPUT> runningSampleStandardDeviationBy(
@@ -356,7 +345,7 @@ public abstract class Gatherers4j {
     /// from a `Stream<INPUT>` via a `mappingFunction`.
     ///
     /// @param mappingFunction A function to map `<INPUT>` objects to `BigDecimal`, the results of which will be used
-    ///                                                                      in the running sum calculation
+    ///                                                                                             in the running sum calculation
     /// @param <INPUT>         Type of elements in the input stream, to be remapped to `BigDecimal` by the `mappingFunction`
     /// @return A non-null `BigDecimalSumGatherer`
     public static <INPUT extends @Nullable Object> BigDecimalSumGatherer<INPUT> runningSumBy(
@@ -399,7 +388,7 @@ public abstract class Gatherers4j {
     /// the given function. This is useful when paired with the `withOriginal` function.
     ///
     /// @param mappingFunction A function to map `<INPUT>` objects to `BigDecimal`, the results of which will be used
-    ///                                               in the running average calculation
+    ///                                                                      in the running average calculation
     /// @param <INPUT>         Type of elements in the input stream, to be remapped to `BigDecimal` by the `mappingFunction`
     /// @return A non-null `BigDecimalSimpleAverageGatherer`
     public static <INPUT extends @Nullable Object> BigDecimalSimpleAverageGatherer<INPUT> simpleRunningAverageBy(
@@ -422,7 +411,7 @@ public abstract class Gatherers4j {
     ///
     /// @param windowSize      The number of elements to average, must be greater than 1.
     /// @param mappingFunction A function to map `<INPUT>` objects to `BigDecimal`, the results of which will be used
-    ///                        in the moving average calculation
+    ///                                               in the moving average calculation
     /// @param <INPUT>         Type of elements in the input stream, to be remapped to `BigDecimal` by the `mappingFunction`
     /// @return A non-null `BigDecimalSimpleMovingAverageGatherer`
     public static <INPUT extends @Nullable Object> BigDecimalSimpleMovingAverageGatherer<INPUT> simpleMovingAverageBy(
@@ -430,6 +419,61 @@ public abstract class Gatherers4j {
             final Function<INPUT, BigDecimal> mappingFunction
     ) {
         return new BigDecimalSimpleMovingAverageGatherer<>(windowSize, mappingFunction);
+    }
+
+    /// Ensure the input stream is exactly `size` elements long, and emit all elements if so.
+    /// If not, throw an `IllegalStateException`.
+    ///
+    /// @param size    Exact number of elements the stream must have
+    /// @param <INPUT> Type of elements in both the input and output streams
+    /// @return A non-null `SizeGatherer`
+    /// @throws IllegalStateException when the input stream is not exactly `size` elements long
+    public static <INPUT extends @Nullable Object> SizeGatherer<INPUT> sizeExactly(final long size) {
+        return new SizeGatherer<>(SizeGatherer.Operation.Equal, size);
+    }
+
+    /// Ensure the input stream is greater than `size` elements long, and emit all elements if so.
+    /// If not, throw an `IllegalStateException`.
+    ///
+    /// @param size The size the stream must be longer than
+    /// @param <INPUT> Type of elements in both the input and output streams
+    /// @return A non-null `SizeGatherer`
+    /// @throws IllegalStateException when the input stream is not exactly `size` elements long
+    public static <INPUT extends @Nullable Object> SizeGatherer<INPUT> sizeGreaterThan(final long size) {
+        return new SizeGatherer<>(SizeGatherer.Operation.GreaterThan, size);
+    }
+
+    /// Ensure the input stream is greater than or equal to `size` elements long, and emit all elements if so.
+    /// If not, throw an `IllegalStateException`.
+    ///
+    /// @param size The minimum size of the stream
+    /// @param <INPUT> Type of elements in both the input and output streams
+    /// @return A non-null `SizeGatherer`
+    /// @throws IllegalStateException when the input stream is not exactly `size` elements long
+    public static <INPUT extends @Nullable Object> SizeGatherer<INPUT> sizeGreaterThanOrEqualTo(final long size) {
+        return new SizeGatherer<>(SizeGatherer.Operation.GreaterThanOrEqualTo, size);
+    }
+
+    /// Ensure the input stream is less than `size` elements long, and emit all elements if so.
+    /// If not, throw an `IllegalStateException`.
+    ///
+    /// @param size The size the stream must be shorter than
+    /// @param <INPUT> Type of elements in both the input and output streams
+    /// @return A non-null `SizeGatherer`
+    /// @throws IllegalStateException when the input stream is not exactly `size` elements long
+    public static <INPUT extends @Nullable Object> SizeGatherer<INPUT> sizeLessThan(final long size) {
+        return new SizeGatherer<>(SizeGatherer.Operation.LessThan, size);
+    }
+
+    /// Ensure the input stream is less than or equal to `size` elements long, and emit all elements if so.
+    /// If not, throw an `IllegalStateException`.
+    ///
+    /// @param size The maximum size the stream
+    /// @param <INPUT> Type of elements in both the input and output streams
+    /// @return A non-null `SizeGatherer`
+    /// @throws IllegalStateException when the input stream is not exactly `size` elements long
+    public static <INPUT extends @Nullable Object> SizeGatherer<INPUT> sizeLessThanOrEqualTo(final long size) {
+        return new SizeGatherer<>(SizeGatherer.Operation.LessThanOrEqualTo, size);
     }
 
     /// Limit the number of elements in the stream to some number per period. When the limit is reached,

--- a/src/main/java/com/ginsberg/gatherers4j/SizeGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/SizeGatherer.java
@@ -28,12 +28,22 @@ public class SizeGatherer<INPUT extends @Nullable Object>
         implements Gatherer<INPUT, SizeGatherer.State<INPUT>, INPUT> {
 
     private final long targetSize;
+    private final Operation operation;
 
-    SizeGatherer(long targetSize) {
+    SizeGatherer(final Operation operation, final long targetSize) {
         if (targetSize < 0) {
             throw new IllegalArgumentException("Target size cannot be negative");
         }
+        this.operation = operation;
         this.targetSize = targetSize;
+    }
+
+    @Override
+    public BiConsumer<State<INPUT>, Downstream<? super INPUT>> finisher() {
+        return (state, downstream) -> {
+            operation.checkFinalLength(state.elements.size(), targetSize);
+            state.elements.forEach(downstream::push);
+        };
     }
 
     @Override
@@ -44,27 +54,100 @@ public class SizeGatherer<INPUT extends @Nullable Object>
     @Override
     public Integrator<State<INPUT>, INPUT, INPUT> integrator() {
         return (state, element, downstream) -> {
+            operation.tryAccept(state.elements.size() + 1, targetSize);
             state.elements.add(element);
-            if (state.elements.size() > targetSize) {
-                fail();
-            }
             return !downstream.isRejecting();
         };
     }
 
-    @Override
-    public BiConsumer<State<INPUT>, Downstream<? super INPUT>> finisher() {
-        return (state, downstream) -> {
-            if (state.elements.size() == targetSize) {
-                state.elements.forEach(downstream::push);
-            } else {
-                fail();
+    enum Operation {
+        Equal {
+            @Override
+            void tryAccept(long length, long target) {
+                if(length > target) {
+                    fail(target);
+                }
+            }
+
+            @Override
+            void checkFinalLength(long length, long target) {
+                if (length != target) {
+                    fail(target);
+                }
+            }
+
+            void fail(long target) {
+                throw new IllegalStateException("Stream length must be equal to " + target);
+            }
+        },
+        GreaterThan {
+            @Override
+            void checkFinalLength(long length, long target) {
+                if (length <= target) {
+                    fail(target);
+                }
+            }
+
+            void fail(long target) {
+                throw new IllegalStateException("Stream length must be greater than " + target);
+            }
+
+        },
+        GreaterThanOrEqualTo {
+            @Override
+            void checkFinalLength(long length, long target) {
+                if (length < target) {
+                    fail(target);
+                }
+            }
+
+            void fail(long target) {
+                throw new IllegalStateException("Stream length must be greater than or equal to " + target);
+            }
+        },
+        LessThan {
+            @Override
+            void tryAccept(long length, long target) {
+                if(length >= target) {
+                    fail(target);
+                }
+            }
+
+            @Override
+            void checkFinalLength(long length, long target) {
+                if (length >= target) {
+                    fail(target);
+                }
+            }
+
+            void fail(long target) {
+                throw new IllegalStateException("Stream length must be less than " + target);
+            }
+        },
+        LessThanOrEqualTo {
+            @Override
+            void tryAccept(long length, long target) {
+                if(length > target) {
+                    fail(target);
+                }
+            }
+
+            @Override
+            void checkFinalLength(long length, long target) {
+                if (length > target) {
+                    fail(target);
+                }
+            }
+
+            void fail(long target) {
+                throw new IllegalStateException("Stream length must be less than or equal to " + target);
             }
         };
-    }
 
-    private void fail() {
-        throw new IllegalStateException("Size must be exactly " + targetSize);
+        abstract void checkFinalLength(long length, long target);
+        void tryAccept(long length, long target){
+            // Empty implementation
+        }
     }
 
     public static class State<INPUT> {

--- a/src/test/java/com/ginsberg/gatherers4j/SizeGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/SizeGathererTest.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -26,37 +27,176 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SizeGathererTest {
 
-    @Test
-    void sizeMustNotBeNegative() {
-        assertThatThrownBy(() ->
-                Stream.empty().gather(Gatherers4j.exactSize(-1)).toList()
-        ).isInstanceOf(IllegalArgumentException.class);
+
+    @Nested
+    class Common {
+        @Test
+        void targetSizeMustNotBeNegative() {
+            assertThatThrownBy(() ->
+                    Stream.empty().gather(Gatherers4j.sizeExactly(-1)).toList()
+            ).isInstanceOf(IllegalArgumentException.class);
+        }
     }
 
-    @Test
-    void doesNotEmitUnderTarget() {
-        assertThatThrownBy(() ->
-                Stream.of("A").gather(Gatherers4j.exactSize(2)).toList()
-        ).isInstanceOf(IllegalStateException.class);
+    @Nested
+    class Equal {
+
+        @Test
+        void doesNotEmitUnderTarget() {
+            assertThatThrownBy(() ->
+                    Stream.of("A").gather(Gatherers4j.sizeExactly(2)).toList()
+            ).isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        void doesNotEmitOverTarget() {
+            assertThatThrownBy(() ->
+                    Stream.of("A", "B", "C").gather(Gatherers4j.sizeExactly(2)).toList()
+            ).isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        void emitsAtTarget() {
+            // Arrange
+            final Stream<String> input = Stream.of("A", "B", "C");
+
+            // Act
+            final List<String> output = input.gather(Gatherers4j.sizeExactly(3)).toList();
+
+            // Assert
+            assertThat(output).containsExactly("A", "B", "C");
+        }
     }
 
-    @Test
-    void doesNotEmitOverTarget() {
-        assertThatThrownBy(() ->
-                Stream.of("A", "B", "C").gather(Gatherers4j.exactSize(2)).toList()
-        ).isInstanceOf(IllegalStateException.class);
+    @Nested
+    class GreaterThan {
+
+        @Test
+        void doesNotEmitUnderTarget() {
+            assertThatThrownBy(() ->
+                    Stream.of("A").gather(Gatherers4j.sizeGreaterThan(2)).toList()
+            ).isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        void doesNotEmitAtTarget() {
+            assertThatThrownBy(() ->
+                    Stream.of("A", "B").gather(Gatherers4j.sizeGreaterThan(2)).toList()
+            ).isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        void emitsOverTarget() {
+            // Arrange
+            final Stream<String> input = Stream.of("A", "B", "C");
+
+            // Act
+            final List<String> output = input.gather(Gatherers4j.sizeGreaterThan(2)).toList();
+
+            // Assert
+            assertThat(output).containsExactly("A", "B", "C");
+        }
     }
 
-    @Test
-    void emitsAtTarget() {
-        // Arrange
-        final Stream<String> input = Stream.of("A", "B", "C");
+    @Nested
+    class GreaterThanOrEqualTo {
 
-        // Act
-        final List<String> output = input.gather(Gatherers4j.exactSize(3)).toList();
+        @Test
+        void doesNotEmitUnderTarget() {
+            assertThatThrownBy(() ->
+                    Stream.of("A").gather(Gatherers4j.sizeGreaterThanOrEqualTo(2)).toList()
+            ).isInstanceOf(IllegalStateException.class);
+        }
 
-        // Assert
-        assertThat(output).containsExactly("A", "B", "C");
+        @Test
+        void emitsAtTarget() {
+            // Arrange
+            final Stream<String> input = Stream.of("A", "B");
+
+            // Act
+            final List<String> output = input.gather(Gatherers4j.sizeGreaterThanOrEqualTo(2)).toList();
+
+            // Assert
+            assertThat(output).containsExactly("A", "B");
+        }
+
+        @Test
+        void emitsOverTarget() {
+            // Arrange
+            final Stream<String> input = Stream.of("A", "B", "C");
+
+            // Act
+            final List<String> output = input.gather(Gatherers4j.sizeGreaterThanOrEqualTo(2)).toList();
+
+            // Assert
+            assertThat(output).containsExactly("A", "B", "C");
+        }
+
     }
 
+    @Nested
+    class LessThan {
+
+        @Test
+        void emitsUnderTarget() {
+            // Arrange
+            final Stream<String> input = Stream.of("A");
+
+            // Act
+            final List<String> output = input.gather(Gatherers4j.sizeLessThan(2)).toList();
+
+            // Assert
+            assertThat(output).containsExactly("A");
+        }
+
+        @Test
+        void doesNotEmitAtTarget() {
+            assertThatThrownBy(() ->
+                    Stream.of("A", "B").gather(Gatherers4j.sizeLessThan(2)).toList()
+            ).isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        void doesNotEmitOverTarget() {
+            assertThatThrownBy(() ->
+                    Stream.of("A", "B", "C").gather(Gatherers4j.sizeLessThan(2)).toList()
+            ).isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+
+    @Nested
+    class LessThanOrEqualTo {
+
+        @Test
+        void emitsUnderTarget() {
+            // Arrange
+            final Stream<String> input = Stream.of("A");
+
+            // Act
+            final List<String> output = input.gather(Gatherers4j.sizeLessThanOrEqualTo(2)).toList();
+
+            // Assert
+            assertThat(output).containsExactly("A");
+        }
+
+        @Test
+        void emitsAtTarget() {
+            // Arrange
+            final Stream<String> input = Stream.of("A", "B");
+
+            // Act
+            final List<String> output = input.gather(Gatherers4j.sizeLessThanOrEqualTo(2)).toList();
+
+            // Assert
+            assertThat(output).containsExactly("A", "B");
+        }
+
+        @Test
+        void doesNotEmitOverTarget() {
+            assertThatThrownBy(() ->
+                    Stream.of("A", "B", "C").gather(Gatherers4j.sizeLessThanOrEqualTo(2)).toList()
+            ).isInstanceOf(IllegalStateException.class);
+        }
+    }
 }


### PR DESCRIPTION
+ Rename `exactSize(n)` to `sizeExactly(n)`
+ Add `sizeGreaterThan(n)`
+ Add `sizeGreaterThanOrEqualTo(n)`
+ Add `sizeLessThan(n)`
+ Add `sizeLessThanOrEqualTo(n)`