### PR TITLE
Implement `windowed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.9.0
 + GH-86: Implement `filterInstanceOf` to filter a stream by type more easily (thanks @nipafx) 
++ Implement `windowed` to provide more options to windowing functions, namely - ability to specify size, how many to skip each time, and whether to include partial windows
 
 ### 0.8.0 
 + Add support for `orElse()` and `orElseEmpty()` on size-based gatherers to provide a non-exceptional output stream

--- a/README.md
+++ b/README.md
@@ -31,45 +31,46 @@ implementation("com.ginsberg:gatherers4j:0.9.0")
 
 ### Streams
 
-| Function                       | Purpose                                                                                                                        |
-|--------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cross(iterable)`              | Emit each element of the source stream with each element of the given `iterable` as a `Pair` to the output stream              |
-| `cross(iterator)`              | Emit each element of the source stream with each element of the given `iterator` as a `Pair` to the output stream              |
-| `cross(stream)`                | Emit each element of the source stream with each element of the given `stream` as a `Pair` to the output stream                |
-| `debounce(amount, duration)`   | Limit stream elements to `amount` elements over `duration`, dropping any elements over the limit until a new `duration` starts |
-| `dedupeConsecutive()`          | Remove consecutive duplicates from a stream                                                                                    |
-| `dedupeConsecutiveBy(fn)`      | Remove consecutive duplicates from a stream as returned by `fn`                                                                |
-| `distinctBy(fn)`               | Emit only distinct elements from the stream, as measured by `fn`                                                               |
-| `dropLast(n)`                  | Keep all but the last `n` elements of the stream                                                                               |
-| `everyNth(n)`                  | Limit the stream to every `n`<sup>th</sup> element                                                                             |
-| `filterInstanceOf(types)`      | Filter the stream to only include elements of the given type(s)                                                                |
-| `filterWithIndex(predicate)`   | Filter the stream with the given `predicate`, which takes an `element` and its `index`                                         |
-| `foldIndexed(fn)`              | Perform a fold over the input stream where each element is included along with its index                                       |
-| `grouping()`                   | Group consecutive identical elements into lists                                                                                |
-| `groupingBy(fn)`               | Group consecutive elements that are identical according to `fn` into lists                                                     |                                                                                                                    
-| `interleave(iterable)`         | Creates a stream of alternating objects from the input stream and the argument iterable                                        |
-| `interleave(iterator)`         | Creates a stream of alternating objects from the input stream and the argument iterator                                        |
-| `interleave(stream)`           | Creates a stream of alternating objects from the input stream and the argument stream                                          |
-| `last(n)`                      | Constrain the stream to the last `n` values                                                                                    |
-| `orderByFrequencyAscending()`  | Returns a stream where elements are ordered from least to most frequent as `WithCount<T>` wrapper objects.                     |
-| `orderByFrequencyDescending()` | Returns a stream where elements are ordered from most to least frequent as `WithCount<T>` wrapper objects.                     |
-| `reverse()`                    | Reverse the order of the stream                                                                                                |
-| `scanIndexed(fn)`              | Performs a scan on the input stream using the given function, and includes the index of the elements                           |
-| `shuffle()`                    | Shuffle the stream into a random order using the platform default `RandomGenerator`                                            |
-| `shuffle(rg)`                  | Shuffle the stream into a random order using the specified `RandomGenerator`                                                   |
-| `sizeExactly(n)`               | Ensure the stream is exactly `n` elements long, or throw an `IllegalStateException`                                            |
-| `sizeGreaterThan(n)`           | Ensure the stream is greater than `n` elements long, or throw an `IllegalStateException`                                       |
-| `sizeGreaterThanOrEqualTo(n)`  | Ensure the stream is greater than or equal to `n` elements long, or throw an `IllegalStateException`                           |
-| `sizeLessThan(n)`              | Ensure the stream is less than `n` elements long, or throw an `IllegalStateException`                                          |
-| `sizeLessThanOrEqualTo(n)`     | Ensure the stream is less than or equal to `n` elements long, or throw an `IllegalStateException`                              |
-| `takeUntil(predicate)`         | Take elements from the input stream until the `predicate` is met, including the first element that matches the `preciate`      |
-| `throttle(amount, duration)`   | Limit stream elements to `amount` elements over `duration`, pausing until a new `duration` period starts                       |
-| `uniquelyOccurring()`          | Emit elements that occur a single time, dropping all others                                                                    |
-| `withIndex()`                  | Maps all elements of the stream as-is along with their 0-based index                                                           |
-| `zipWith(iterable)`            | Creates a stream of `Pair` objects whose values come from the input stream and argument iterable                               |
-| `zipWith(iterator)`            | Creates a stream of `Pair` objects whose values come from the input stream and argument iterator                               |
-| `zipWith(stream)`              | Creates a stream of `Pair` objects whose values come from the input stream and argument stream                                 |
-| `zipWithNext()`                | Creates a stream of `List` objects via a sliding window of width 2 and stepping 1                                              |      
+| Function                       | Purpose                                                                                                                                            |
+|--------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `cross(iterable)`              | Emit each element of the source stream with each element of the given `iterable` as a `Pair` to the output stream                                  |
+| `cross(iterator)`              | Emit each element of the source stream with each element of the given `iterator` as a `Pair` to the output stream                                  |
+| `cross(stream)`                | Emit each element of the source stream with each element of the given `stream` as a `Pair` to the output stream                                    |
+| `debounce(amount, duration)`   | Limit stream elements to `amount` elements over `duration`, dropping any elements over the limit until a new `duration` starts                     |
+| `dedupeConsecutive()`          | Remove consecutive duplicates from a stream                                                                                                        |
+| `dedupeConsecutiveBy(fn)`      | Remove consecutive duplicates from a stream as returned by `fn`                                                                                    |
+| `distinctBy(fn)`               | Emit only distinct elements from the stream, as measured by `fn`                                                                                   |
+| `dropLast(n)`                  | Keep all but the last `n` elements of the stream                                                                                                   |
+| `everyNth(n)`                  | Limit the stream to every `n`<sup>th</sup> element                                                                                                 |
+| `filterInstanceOf(types)`      | Filter the stream to only include elements of the given type(s)                                                                                    |
+| `filterWithIndex(predicate)`   | Filter the stream with the given `predicate`, which takes an `element` and its `index`                                                             |
+| `foldIndexed(fn)`              | Perform a fold over the input stream where each element is included along with its index                                                           |
+| `grouping()`                   | Group consecutive identical elements into lists                                                                                                    |
+| `groupingBy(fn)`               | Group consecutive elements that are identical according to `fn` into lists                                                                         |                                                                                                                    
+| `interleave(iterable)`         | Creates a stream of alternating objects from the input stream and the argument iterable                                                            |
+| `interleave(iterator)`         | Creates a stream of alternating objects from the input stream and the argument iterator                                                            |
+| `interleave(stream)`           | Creates a stream of alternating objects from the input stream and the argument stream                                                              |
+| `last(n)`                      | Constrain the stream to the last `n` values                                                                                                        |
+| `orderByFrequencyAscending()`  | Returns a stream where elements are ordered from least to most frequent as `WithCount<T>` wrapper objects.                                         |
+| `orderByFrequencyDescending()` | Returns a stream where elements are ordered from most to least frequent as `WithCount<T>` wrapper objects.                                         |
+| `reverse()`                    | Reverse the order of the stream                                                                                                                    |
+| `scanIndexed(fn)`              | Performs a scan on the input stream using the given function, and includes the index of the elements                                               |
+| `shuffle()`                    | Shuffle the stream into a random order using the platform default `RandomGenerator`                                                                |
+| `shuffle(rg)`                  | Shuffle the stream into a random order using the specified `RandomGenerator`                                                                       |
+| `sizeExactly(n)`               | Ensure the stream is exactly `n` elements long, or throw an `IllegalStateException`                                                                |
+| `sizeGreaterThan(n)`           | Ensure the stream is greater than `n` elements long, or throw an `IllegalStateException`                                                           |
+| `sizeGreaterThanOrEqualTo(n)`  | Ensure the stream is greater than or equal to `n` elements long, or throw an `IllegalStateException`                                               |
+| `sizeLessThan(n)`              | Ensure the stream is less than `n` elements long, or throw an `IllegalStateException`                                                              |
+| `sizeLessThanOrEqualTo(n)`     | Ensure the stream is less than or equal to `n` elements long, or throw an `IllegalStateException`                                                  |
+| `takeUntil(predicate)`         | Take elements from the input stream until the `predicate` is met, including the first element that matches the `preciate`                          |
+| `throttle(amount, duration)`   | Limit stream elements to `amount` elements over `duration`, pausing until a new `duration` period starts                                           |
+| `uniquelyOccurring()`          | Emit elements that occur a single time, dropping all others                                                                                        |
+| `windowed(size,step,partial)   | Create windows over the input stream that are `size` elements long, sliding over `step` elements each time, optionally including `partial` windows |
+| `withIndex()`                  | Maps all elements of the stream as-is along with their 0-based index                                                                               |
+| `zipWith(iterable)`            | Creates a stream of `Pair` objects whose values come from the input stream and argument iterable                                                   |
+| `zipWith(iterator)`            | Creates a stream of `Pair` objects whose values come from the input stream and argument iterator                                                   |
+| `zipWith(stream)`              | Creates a stream of `Pair` objects whose values come from the input stream and argument stream                                                     |
+| `zipWithNext()`                | Creates a stream of `List` objects via a sliding window of width 2 and stepping 1                                                                  |      
 
 ### Mathematics/Statistics
 
@@ -502,6 +503,28 @@ Stream
 
 // ["B", "C"]
 ```
+
+#### Get a windowed view of a stream
+
+```java
+// Window size 3, stepping 2, without partials
+Stream.of("A", "B", "C", "D", "E", "F")
+    .gather(Gatherers4j.windowed(3, 2, false))
+    .toList();
+
+// [ ["A", "B", "C"], ["C", "D", "E"] ]
+```
+
+```java
+// Window size 3, stepping 2, with partials
+Stream.of("A", "B", "C", "D", "E", "F")
+    .gather(Gatherers4j.windowed(3, 2, true))
+    .toList();
+
+// [ ["A", "B", "C"], ["C", "D", "E"], ["E, "F"] ]
+
+```
+
 
 #### Zip two streams of together into a `Stream<Pair>`
 

--- a/src/main/java/com/ginsberg/gatherers4j/Gatherers4j.java
+++ b/src/main/java/com/ginsberg/gatherers4j/Gatherers4j.java
@@ -617,6 +617,18 @@ public abstract class Gatherers4j {
         return new UniquelyOccurringGatherer<>();
     }
 
+    /// Create windows over the elements of the input stream that are `windowSize` in length, sliding over `stepping` number of elements
+    /// and optionally including partial windows at the end of ths stream.
+    ///
+    /// @param <INPUT> Type of elements in the input and output stream
+    /// @param windowSize Size of the window, must be greater than 0
+    /// @param stepping Number of elements to slide over each time a window has filled, must be greater than 0
+    /// @param includePartials To include left-over partial windows at the end of the stream or not
+    /// @return A non-null `WindowedGatherer`
+    public static <INPUT extends @Nullable Object> WindowedGatherer<INPUT> windowed(int windowSize, int stepping, boolean includePartials) {
+        return new WindowedGatherer<>(windowSize, stepping, includePartials);
+    }
+
     /// Maps all elements of the stream as-is along with their 0-based index.
     ///
     /// @param <INPUT> Type of elements in the input stream

--- a/src/main/java/com/ginsberg/gatherers4j/WindowedGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/WindowedGatherer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 Todd Ginsberg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ginsberg.gatherers4j;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+import java.util.stream.Gatherer;
+
+public class WindowedGatherer<INPUT extends @Nullable Object>
+        implements Gatherer<INPUT, WindowedGatherer.State<INPUT>, List<INPUT>> {
+
+    private final boolean includePartials;
+    private final int stepping;
+    private final int windowSize;
+
+    WindowedGatherer(final int windowSize, final int stepping, final boolean includePartials) {
+        if (windowSize <= 0) {
+            throw new IllegalArgumentException("Window size must be greater than zero");
+        }
+        if (stepping <= 0) {
+            throw new IllegalArgumentException("Stepping must be greater than zero");
+        }
+        this.windowSize = windowSize;
+        this.stepping = stepping;
+        this.includePartials = includePartials;
+    }
+
+    @Override
+    public Supplier<State<INPUT>> initializer() {
+        return State::new;
+    }
+
+    @Override
+    public Integrator<State<INPUT>, INPUT, List<INPUT>> integrator() {
+        return Integrator.ofGreedy((state, element, downstream) -> {
+            if (state.stepDelta == 0) {
+                state.window.add(element);
+            } else {
+                state.stepDelta--;
+            }
+            if (state.window.size() == windowSize) {
+                downstream.push(List.copyOf(state.window));
+                state.stepDelta = Math.max(0, stepping - windowSize);
+
+                if (stepping >= windowSize) {
+                    state.window.clear();
+                } else {
+                    for (int i = 0; i < stepping; i++) {
+                        state.window.removeFirst();
+                    }
+                }
+            }
+            return !downstream.isRejecting();
+        });
+    }
+
+    @Override
+    public BiConsumer<State<INPUT>, Downstream<? super List<INPUT>>> finisher() {
+        return (inputState, downstream) -> {
+            if (includePartials && !inputState.window.isEmpty()) {
+                downstream.push(List.copyOf(inputState.window));
+            }
+        };
+    }
+
+    public static class State<INPUT> {
+        int stepDelta = 0;
+        final Deque<INPUT> window = new ArrayDeque<>();
+    }
+}

--- a/src/test/java/com/ginsberg/gatherers4j/WindowedGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/WindowedGathererTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2025 Todd Ginsberg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ginsberg.gatherers4j;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WindowedGathererTest {
+
+    @Test
+    void emptyStream() {
+        // Arrange
+        final Stream<String> input = Stream.empty();
+
+        // Act
+        final List<List<String>> output = input.gather(
+                Gatherers4j.windowed(1, 1, true)
+        ).toList();
+
+        // Assert
+        assertThat(output).isEmpty();
+    }
+
+    @Test
+    void excludesPartialWindow() {
+        // Arrange
+        final Stream<String> input = Stream.of("A", "B", "C", "D", "E");
+
+        // Act
+        final List<List<String>> output = input.gather(
+                Gatherers4j.windowed(2, 2, false)
+        ).toList();
+
+        // Assert
+        assertThat(output)
+                .containsExactly(
+                        List.of("A", "B"),
+                        List.of("C", "D")
+                );
+    }
+
+    @Test
+    void includesPartialWindow() {
+        // Arrange
+        final Stream<String> input = Stream.of("A", "B", "C", "D", "E");
+
+        // Act
+        final List<List<String>> output = input.gather(
+                Gatherers4j.windowed(2, 2, true)
+        ).toList();
+
+        // Assert
+        assertThat(output)
+                .containsExactly(
+                        List.of("A", "B"),
+                        List.of("C", "D"),
+                        List.of("E")
+                );
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0})
+    void steppingMustBePositive(int stepping) {
+        assertThatThrownBy(() -> new WindowedGatherer<>(1, stepping, true))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0})
+    void windowSizeMustBePositive(int windowSize) {
+        assertThatThrownBy(() -> new WindowedGatherer<>(windowSize, 1, true))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void windowWithSteppingAndPartials() {
+        // Arrange
+        final Stream<String> input = Stream.of("A", "B", "C", "D", "E", "F");
+
+        // Act
+        final List<List<String>> output = input.gather(
+                Gatherers4j.windowed(3, 2, true)
+        ).toList();
+
+        // Assert
+        assertThat(output)
+                .containsExactly(
+                        List.of("A", "B", "C"),
+                        List.of("C", "D", "E"),
+                        List.of("E", "F")
+                );
+    }
+
+    @Test
+    void windowWithSteppingThatSkips() {
+        // Arrange
+        final Stream<String> input = Stream.of("A", "B", "C", "D", "E", "F");
+
+        // Act
+        final List<List<String>> output = input.gather(
+                Gatherers4j.windowed(2, 3, true)
+        ).toList();
+
+        // Assert
+        assertThat(output)
+                .containsExactly(
+                        List.of("A", "B"),
+                        List.of("D", "E")
+                );
+    }
+
+}


### PR DESCRIPTION
+ Offers more flexibility than the JDK version of `windowFixed` and `windowSliding`
+ Allows caller to specify window size, how far to step over for each window, and whether to emit a partial windows at the end of the stream if one exists