### PR TITLE
Make lists returned from groupBy calls unmodifiable

### DIFF
--- a/src/main/java/com/ginsberg/gatherers4j/Gatherers4j.java
+++ b/src/main/java/com/ginsberg/gatherers4j/Gatherers4j.java
@@ -472,8 +472,8 @@ public abstract class Gatherers4j {
         return GroupChangingGatherer.usingComparator(ChangingOperation.NonIncreasing, comparator);
     }
 
-    /// Turn a `Stream<INPUT>` into a `Stream<List<INPUT>>` where consecutive
-    /// equal elements, where equality is measured by `Object.equals(Object)`.
+    /// Turn a `Stream<INPUT>` into a `Stream<List<INPUT>>` where consecutive equal elements are in the same `List`
+    /// and equality is measured by `Object.equals(Object)`. The lists emitted to the output stream are unmodifiable.
     ///
     /// @param <INPUT> Type of elements in the input stream
     /// @return A non-null `GroupingByGatherer`
@@ -481,8 +481,8 @@ public abstract class Gatherers4j {
         return new GroupingByGatherer<>();
     }
 
-    /// Turn a `Stream<INPUT>` into a `Stream<List<INPUT>>` where consecutive
-    /// equal elements, where equality is measured by the given `mappingFunction`, are in the same `List`.
+    /// Turn a `Stream<INPUT>` into a `Stream<List<INPUT>>` where consecutive equal elements are in the same `List`
+    /// and equality is measured by the given `mappingFunction`. The lists emitted to the output stream are unmodifiable.
     ///
     /// @param mappingFunction A non-null function, the results of which are used to measure equality of consecutive elements.
     /// @param <INPUT>         Type of elements in the input stream

--- a/src/test/java/com/ginsberg/gatherers4j/GroupingByGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/GroupingByGathererTest.java
@@ -74,6 +74,7 @@ class GroupingByGathererTest {
         );
     }
 
+    @SuppressWarnings("DataFlowIssue")
     @Test
     void mappingFunctionMustNotBeNull() {
         assertThatThrownBy(() -> new GroupingByGatherer<>(null)).isInstanceOf(IllegalArgumentException.class);
@@ -94,6 +95,23 @@ class GroupingByGathererTest {
                         Arrays.asList(null, null),
                         List.of("A")
                 );
+    }
+
+    @Test
+    void returnedListUnmodifiable() {
+        // Arrange
+        final Stream<String> input = Stream.of("A", "A", "B", "B", "C", "C", "C");
+
+        // Act
+        final List<List<String>> output = input.gather(Gatherers4j.grouping()).toList();
+
+        // Assert
+        assertThat(output).hasSize(3);
+        output.forEach(it ->
+                assertThatThrownBy(() ->
+                        it.add("D")
+                ).isInstanceOf(UnsupportedOperationException.class)
+        );
     }
 
     @Test


### PR DESCRIPTION
+ Reimplement integrator to be slightly easier to follow
+ FWIW I also reimplemented this entirely with the `GroupChangingGatherer` but it felt clumsy so here we are