### PR TITLE
Consistency fix: Rename IndexedValue to WithIndex

### DIFF
--- a/docs/gatherers4j/content/changelog/_index.md
+++ b/docs/gatherers4j/content/changelog/_index.md
@@ -8,6 +8,7 @@ no_list: true
 ## v0.10.0
 
 + Implement `mapIndexed()` to perform a mapping operation given the element being mapped and its zero-based index
++ Rename `IndexedValue` to `WithIndex`, for consistency (matching `WithCount` and `WithOriginal`)
 
 ## v0.9.0
 [Released 2025-02-23](https://github.com/tginsberg/gatherers4j/releases/tag/v0.9.0)

--- a/docs/gatherers4j/content/gatherers/sequence-operations/withIndex.md
+++ b/docs/gatherers4j/content/gatherers/sequence-operations/withIndex.md
@@ -9,7 +9,7 @@ description: Maps all elements of the stream as-is along with their 0-based inde
 
 ### Implementation Notes
 
-Each element of the input stream is mapped to a [`IndexedValue`](https://github.com/tginsberg/gatherers4j/blob/main/src/main/java/com/ginsberg/gatherers4j/IndexedValue.java)record along with its zero-based index. As of now
+Each element of the input stream is mapped to a [`WithIndex`](https://github.com/tginsberg/gatherers4j/blob/main/src/main/java/com/ginsberg/gatherers4j/WithIndex.java)record along with its zero-based index. As of now
 does not provide a `mapWithIndex()` functionality but that is on the roadmap.
 
 **Signature**
@@ -26,6 +26,6 @@ Stream
     .gather(Gatherers4j.withIndex())
     .toList();
 
-// [ IndexedValue(0, "A"), IndexedValue(1, "B"), IndexedValue(2, "C") ]
+// [ WithIndex(0, "A"), WithIndex(1, "B"), WithIndex(2, "C") ]
 ```
 

--- a/src/main/java/com/ginsberg/gatherers4j/Gatherers4j.java
+++ b/src/main/java/com/ginsberg/gatherers4j/Gatherers4j.java
@@ -715,7 +715,7 @@ public abstract class Gatherers4j {
     ///
     /// @param <INPUT> Type of elements in the input stream
     /// @return A non-null `SimpleIndexingGatherers`
-    public static <INPUT extends @Nullable Object> Gatherer<INPUT, ?, IndexedValue<INPUT>> withIndex() {
+    public static <INPUT extends @Nullable Object> Gatherer<INPUT, ?, WithIndex<INPUT>> withIndex() {
         return SimpleIndexingGatherers.withIndex();
     }
 

--- a/src/main/java/com/ginsberg/gatherers4j/SimpleIndexingGatherers.java
+++ b/src/main/java/com/ginsberg/gatherers4j/SimpleIndexingGatherers.java
@@ -53,8 +53,8 @@ public class SimpleIndexingGatherers {
         );
     }
 
-    public static <INPUT extends @Nullable Object> Gatherer<INPUT, ?, IndexedValue<INPUT>> withIndex() {
-        return mapIndexed(IndexedValue::new);
+    public static <INPUT extends @Nullable Object> Gatherer<INPUT, ?, WithIndex<INPUT>> withIndex() {
+        return mapIndexed(WithIndex::new);
     }
 
     private static class State {

--- a/src/main/java/com/ginsberg/gatherers4j/WithIndex.java
+++ b/src/main/java/com/ginsberg/gatherers4j/WithIndex.java
@@ -18,7 +18,7 @@ package com.ginsberg.gatherers4j;
 
 import org.jspecify.annotations.Nullable;
 
-public record IndexedValue<TYPE>(
+public record WithIndex<TYPE>(
         long index,
         @Nullable TYPE value
 ) {

--- a/src/test/java/com/ginsberg/gatherers4j/AccumulatingGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/AccumulatingGathererTest.java
@@ -43,13 +43,13 @@ public class AccumulatingGathererTest {
             final Stream<String> input = Stream.of("A", "B", "C", "D");
 
             // Act
-            final List<IndexedValue<String>> output = input
+            final List<WithIndex<String>> output = input
                     .gather(
                             Gatherers4j.foldIndexed(
-                                    () -> new ArrayList<IndexedValue<String>>(),
+                                    () -> new ArrayList<WithIndex<String>>(),
                                     (index, carry, next) -> {
                                         assert carry != null;
-                                        carry.add(new IndexedValue<>(index, next));
+                                        carry.add(new WithIndex<>(index, next));
                                         return carry;
                                     }
                             )
@@ -60,10 +60,10 @@ public class AccumulatingGathererTest {
             // Assert
             assertThat(output)
                     .containsExactly(
-                            new IndexedValue<>(0, "A"),
-                            new IndexedValue<>(1, "B"),
-                            new IndexedValue<>(2, "C"),
-                            new IndexedValue<>(3, "D")
+                            new WithIndex<>(0, "A"),
+                            new WithIndex<>(1, "B"),
+                            new WithIndex<>(2, "C"),
+                            new WithIndex<>(3, "D")
                     );
         }
 

--- a/src/test/java/com/ginsberg/gatherers4j/SimpleIndexingGatherersTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/SimpleIndexingGatherersTest.java
@@ -46,6 +46,7 @@ class SimpleIndexingGatherersTest {
             assertThat(output).containsExactly("A", "C", "D");
         }
 
+        @SuppressWarnings("DataFlowIssue")
         @Test
         void predicateMustNotBeNull() {
             assertThatThrownBy(() -> Stream.of("A").gather(Gatherers4j.filterIndexed(null)))
@@ -55,6 +56,7 @@ class SimpleIndexingGatherersTest {
 
     @Nested
     class MapIndexed {
+        @SuppressWarnings("DataFlowIssue")
         @Test
         void mappingFunctionMustNotBeNull() {
             assertThatThrownBy(() ->
@@ -96,16 +98,16 @@ class SimpleIndexingGatherersTest {
             final Stream<String> input = Stream.of("A", "B", "C");
 
             // Act
-            final List<IndexedValue<String>> output = input
+            final List<com.ginsberg.gatherers4j.WithIndex<String>> output = input
                     .gather(Gatherers4j.withIndex())
                     .toList();
 
             // Assert
             assertThat(output)
                     .containsExactly(
-                            new IndexedValue<>(0, "A"),
-                            new IndexedValue<>(1, "B"),
-                            new IndexedValue<>(2, "C")
+                            new com.ginsberg.gatherers4j.WithIndex<>(0, "A"),
+                            new com.ginsberg.gatherers4j.WithIndex<>(1, "B"),
+                            new com.ginsberg.gatherers4j.WithIndex<>(2, "C")
                     );
         }
 
@@ -115,16 +117,16 @@ class SimpleIndexingGatherersTest {
             final Stream<Integer> input = Stream.of(1, 2, 3);
 
             // Act
-            final List<IndexedValue<Integer>> output = input
+            final List<com.ginsberg.gatherers4j.WithIndex<Integer>> output = input
                     .gather(Gatherers4j.withIndex())
                     .toList();
 
             // Assert
             assertThat(output)
                     .containsExactly(
-                            new IndexedValue<>(0, 1),
-                            new IndexedValue<>(1, 2),
-                            new IndexedValue<>(2, 3)
+                            new com.ginsberg.gatherers4j.WithIndex<>(0, 1),
+                            new com.ginsberg.gatherers4j.WithIndex<>(1, 2),
+                            new com.ginsberg.gatherers4j.WithIndex<>(2, 3)
                     );
         }
     }


### PR DESCRIPTION
Matches WithCount and WithOriginal.
Did not try to alter the order of fields as these objects are intended to be read-only outside the library and order shouldn't really matter. It would have also been a lot of small changes internally for very little gain.