### PR TITLE
Reorganize packages

### DIFF
--- a/src/main/java/com/ginsberg/gatherers4j/AccumulatingGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/AccumulatingGatherer.java
@@ -22,7 +22,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Gatherer;
 
-import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
+import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 
 public class AccumulatingGatherer<INPUT extends @Nullable Object, OUTPUT extends @Nullable Object>
         implements Gatherer<INPUT, AccumulatingGatherer.State<OUTPUT>, OUTPUT> {

--- a/src/main/java/com/ginsberg/gatherers4j/BigDecimalGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/BigDecimalGatherer.java
@@ -23,7 +23,7 @@ import java.math.MathContext;
 import java.util.function.Function;
 import java.util.stream.Gatherer;
 
-import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
+import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 
 abstract public class BigDecimalGatherer<INPUT extends @Nullable Object>
         implements Gatherer<INPUT, BigDecimalGatherer.State, BigDecimal> {

--- a/src/main/java/com/ginsberg/gatherers4j/BigDecimalSimpleAverageGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/BigDecimalSimpleAverageGatherer.java
@@ -23,7 +23,7 @@ import java.math.MathContext;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
+import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 
 public final class BigDecimalSimpleAverageGatherer<INPUT extends @Nullable Object> extends BigDecimalGatherer<INPUT> {
 

--- a/src/main/java/com/ginsberg/gatherers4j/BigDecimalStandardDeviationGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/BigDecimalStandardDeviationGatherer.java
@@ -23,7 +23,7 @@ import java.math.MathContext;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
+import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 
 public final class BigDecimalStandardDeviationGatherer<INPUT extends @Nullable Object> extends BigDecimalGatherer<INPUT> {
 

--- a/src/main/java/com/ginsberg/gatherers4j/CrossGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/CrossGatherer.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.dto.Pair;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Arrays;
@@ -48,7 +49,7 @@ public class CrossGatherer {
     @SafeVarargs
     public static <INPUT extends @Nullable Object, CROSS extends @Nullable Object> Gatherer<INPUT, ?, Pair<INPUT, CROSS>> of(final CROSS... source) {
         mustNotBeNull(source, "source must not be null");
-        // Note: None of the other entrypoints enforce non-empty source, so this one won't either even though it is trivial to do so
+        // Note: None of the other entry points enforce non-empty source, so this one won't either even though it is trivial to do so
         return create(Arrays.asList(source));
     }
 

--- a/src/main/java/com/ginsberg/gatherers4j/CrossGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/CrossGatherer.java
@@ -26,7 +26,7 @@ import java.util.stream.Gatherer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
+import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 
 public class CrossGatherer {
 

--- a/src/main/java/com/ginsberg/gatherers4j/DedupeConsecutiveGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/DedupeConsecutiveGatherer.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Gatherer;
 
-import static com.ginsberg.gatherers4j.GathererUtils.safeEquals;
+import static com.ginsberg.gatherers4j.util.GathererUtils.safeEquals;
 
 public class DedupeConsecutiveGatherer<INPUT extends @Nullable Object>
         implements Gatherer<INPUT, DedupeConsecutiveGatherer.State, INPUT> {

--- a/src/main/java/com/ginsberg/gatherers4j/DistinctGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/DistinctGatherer.java
@@ -24,7 +24,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Gatherer;
 
-import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
+import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 
 public class DistinctGatherer<INPUT extends @Nullable Object>
         implements Gatherer<INPUT, DistinctGatherer.State, INPUT> {

--- a/src/main/java/com/ginsberg/gatherers4j/DropLastGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/DropLastGatherer.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.util.CircularBuffer;
 import org.jspecify.annotations.Nullable;
 
 import java.util.function.Supplier;

--- a/src/main/java/com/ginsberg/gatherers4j/FilterChangingGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/FilterChangingGatherer.java
@@ -23,7 +23,7 @@ import java.util.Comparator;
 import java.util.function.Supplier;
 import java.util.stream.Gatherer;
 
-import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
+import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 
 public class FilterChangingGatherer<INPUT>
         implements Gatherer<INPUT, FilterChangingGatherer.State<INPUT>, INPUT> {

--- a/src/main/java/com/ginsberg/gatherers4j/FrequencyGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/FrequencyGatherer.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.dto.WithCount;
 import com.ginsberg.gatherers4j.enums.Frequency;
 import org.jspecify.annotations.Nullable;
 

--- a/src/main/java/com/ginsberg/gatherers4j/FrequencyGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/FrequencyGatherer.java
@@ -27,7 +27,7 @@ import java.util.function.BinaryOperator;
 import java.util.function.Supplier;
 import java.util.stream.Gatherer;
 
-import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
+import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 
 public class FrequencyGatherer<INPUT extends @Nullable Object>
         implements Gatherer<INPUT, FrequencyGatherer.State<INPUT>, WithCount<INPUT>> {

--- a/src/main/java/com/ginsberg/gatherers4j/Gatherers4j.java
+++ b/src/main/java/com/ginsberg/gatherers4j/Gatherers4j.java
@@ -36,8 +36,8 @@ import java.util.random.RandomGenerator;
 import java.util.stream.Gatherer;
 import java.util.stream.Stream;
 
-import static com.ginsberg.gatherers4j.GathererUtils.equalityOnlyComparator;
-import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
+import static com.ginsberg.gatherers4j.util.GathererUtils.equalityOnlyComparator;
+import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 
 /// This is the main entry-point for the Gatherers4j library. All available gatherers
 /// are created from static methods on this class.

--- a/src/main/java/com/ginsberg/gatherers4j/Gatherers4j.java
+++ b/src/main/java/com/ginsberg/gatherers4j/Gatherers4j.java
@@ -16,6 +16,9 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.dto.Pair;
+import com.ginsberg.gatherers4j.dto.WithCount;
+import com.ginsberg.gatherers4j.dto.WithIndex;
 import com.ginsberg.gatherers4j.enums.Frequency;
 import com.ginsberg.gatherers4j.enums.Order;
 import com.ginsberg.gatherers4j.enums.Rotate;

--- a/src/main/java/com/ginsberg/gatherers4j/GroupChangingGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/GroupChangingGatherer.java
@@ -26,7 +26,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Gatherer;
 
-import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
+import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 
 public class GroupChangingGatherer<INPUT>
         implements Gatherer<INPUT, GroupChangingGatherer.State<INPUT>, List<INPUT>> {

--- a/src/main/java/com/ginsberg/gatherers4j/InterleavingGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/InterleavingGatherer.java
@@ -25,7 +25,7 @@ import java.util.function.BiConsumer;
 import java.util.stream.Gatherer;
 import java.util.stream.Stream;
 
-import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
+import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 
 public class InterleavingGatherer<INPUT extends @Nullable Object>
         implements Gatherer<INPUT, Void, INPUT> {

--- a/src/main/java/com/ginsberg/gatherers4j/LastGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/LastGatherer.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.util.CircularBuffer;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Iterator;

--- a/src/main/java/com/ginsberg/gatherers4j/ShufflingGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/ShufflingGatherer.java
@@ -25,7 +25,7 @@ import java.util.function.Supplier;
 import java.util.random.RandomGenerator;
 import java.util.stream.Gatherer;
 
-import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
+import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 
 public class ShufflingGatherer<INPUT extends @Nullable Object> implements
         Gatherer<INPUT, ShufflingGatherer.State<INPUT>, INPUT> {

--- a/src/main/java/com/ginsberg/gatherers4j/SimpleIndexingGatherers.java
+++ b/src/main/java/com/ginsberg/gatherers4j/SimpleIndexingGatherers.java
@@ -22,7 +22,7 @@ import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import java.util.stream.Gatherer;
 
-import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
+import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 
 public class SimpleIndexingGatherers {
 

--- a/src/main/java/com/ginsberg/gatherers4j/SimpleIndexingGatherers.java
+++ b/src/main/java/com/ginsberg/gatherers4j/SimpleIndexingGatherers.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.dto.WithIndex;
 import org.jspecify.annotations.Nullable;
 
 import java.util.function.BiFunction;

--- a/src/main/java/com/ginsberg/gatherers4j/SizeGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/SizeGatherer.java
@@ -26,7 +26,7 @@ import java.util.function.Supplier;
 import java.util.stream.Gatherer;
 import java.util.stream.Stream;
 
-import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
+import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 
 public class SizeGatherer<INPUT extends @Nullable Object>
         implements Gatherer<INPUT, SizeGatherer.State<INPUT>, INPUT> {

--- a/src/main/java/com/ginsberg/gatherers4j/TakeUntilGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/TakeUntilGatherer.java
@@ -22,7 +22,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Gatherer;
 
-import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
+import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 
 public class TakeUntilGatherer<INPUT extends @Nullable Object>
         implements Gatherer<INPUT, TakeUntilGatherer.State, INPUT> {

--- a/src/main/java/com/ginsberg/gatherers4j/ThrottlingGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/ThrottlingGatherer.java
@@ -24,8 +24,8 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.function.Supplier;
 import java.util.stream.Gatherer;
 
-import static com.ginsberg.gatherers4j.GathererUtils.NANOS_PER_MILLISECOND;
-import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
+import static com.ginsberg.gatherers4j.util.GathererUtils.NANOS_PER_MILLISECOND;
+import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 
 public class ThrottlingGatherer<INPUT extends @Nullable Object>
         implements Gatherer<INPUT, ThrottlingGatherer.State, INPUT> {

--- a/src/main/java/com/ginsberg/gatherers4j/TypeFilteringGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/TypeFilteringGatherer.java
@@ -18,7 +18,7 @@ package com.ginsberg.gatherers4j;
 
 import java.util.stream.Gatherer;
 
-import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
+import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 
 abstract class TypeFilteringGatherer {
 

--- a/src/main/java/com/ginsberg/gatherers4j/WindowGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/WindowGatherer.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.util.CircularBuffer;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;

--- a/src/main/java/com/ginsberg/gatherers4j/WithOriginalGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/WithOriginalGatherer.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.dto.WithOriginal;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Deque;

--- a/src/main/java/com/ginsberg/gatherers4j/ZipWithGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/ZipWithGatherer.java
@@ -26,7 +26,7 @@ import java.util.function.Function;
 import java.util.stream.Gatherer;
 import java.util.stream.Stream;
 
-import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
+import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 
 public class ZipWithGatherer<FIRST extends @Nullable Object, SECOND extends @Nullable Object>
         implements Gatherer<FIRST, Void, Pair<FIRST, SECOND>> {

--- a/src/main/java/com/ginsberg/gatherers4j/ZipWithGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/ZipWithGatherer.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.dto.Pair;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Arrays;

--- a/src/main/java/com/ginsberg/gatherers4j/dto/Pair.java
+++ b/src/main/java/com/ginsberg/gatherers4j/dto/Pair.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 Todd Ginsberg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ginsberg.gatherers4j.dto;
+
+import org.jspecify.annotations.Nullable;
+
+public record Pair<FIRST, SECOND>(
+        @Nullable FIRST first,
+        @Nullable SECOND second
+) {
+}

--- a/src/main/java/com/ginsberg/gatherers4j/dto/WithCount.java
+++ b/src/main/java/com/ginsberg/gatherers4j/dto/WithCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Todd Ginsberg
+ * Copyright 2025 Todd Ginsberg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package com.ginsberg.gatherers4j;
+package com.ginsberg.gatherers4j.dto;
 
 import org.jspecify.annotations.Nullable;
 
-public record WithIndex<TYPE>(
-        long index,
-        @Nullable TYPE value
+public record WithCount<VALUE>(
+        @Nullable VALUE value,
+        long count
 ) {
 }

--- a/src/main/java/com/ginsberg/gatherers4j/dto/WithIndex.java
+++ b/src/main/java/com/ginsberg/gatherers4j/dto/WithIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Todd Ginsberg
+ * Copyright 2025 Todd Ginsberg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package com.ginsberg.gatherers4j;
+package com.ginsberg.gatherers4j.dto;
 
 import org.jspecify.annotations.Nullable;
 
-public record WithOriginal<ORIGINAL, CALCULATED>(
-        @Nullable ORIGINAL original,
-        @Nullable CALCULATED calculated
+public record WithIndex<TYPE>(
+        long index,
+        @Nullable TYPE value
 ) {
 }

--- a/src/main/java/com/ginsberg/gatherers4j/dto/WithOriginal.java
+++ b/src/main/java/com/ginsberg/gatherers4j/dto/WithOriginal.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 Todd Ginsberg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ginsberg.gatherers4j.dto;
+
+import org.jspecify.annotations.Nullable;
+
+public record WithOriginal<ORIGINAL, CALCULATED>(
+        @Nullable ORIGINAL original,
+        @Nullable CALCULATED calculated
+) {
+}

--- a/src/main/java/com/ginsberg/gatherers4j/dto/package-info.java
+++ b/src/main/java/com/ginsberg/gatherers4j/dto/package-info.java
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-package com.ginsberg.gatherers4j;
+/// A library of useful Stream Gatherers (custom intermediate operations) for Java.
+///
+/// @author Todd Ginsberg (todd@ginsberg.com)
+@NullMarked
+package com.ginsberg.gatherers4j.dto;
 
-import org.jspecify.annotations.Nullable;
-
-public record Pair<FIRST, SECOND>(
-        @Nullable FIRST first,
-        @Nullable SECOND second
-) {
-}
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/com/ginsberg/gatherers4j/enums/package-info.java
+++ b/src/main/java/com/ginsberg/gatherers4j/enums/package-info.java
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-package com.ginsberg.gatherers4j;
+/// A library of useful Stream Gatherers (custom intermediate operations) for Java.
+///
+/// @author Todd Ginsberg (todd@ginsberg.com)
+@NullMarked
+package com.ginsberg.gatherers4j.enums;
 
-import org.jspecify.annotations.Nullable;
-
-public record WithCount<VALUE>(
-        @Nullable VALUE value,
-        long count
-) {
-}
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/com/ginsberg/gatherers4j/util/CircularBuffer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/util/CircularBuffer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.ginsberg.gatherers4j;
+package com.ginsberg.gatherers4j.util;
 
 import org.jspecify.annotations.Nullable;
 

--- a/src/main/java/com/ginsberg/gatherers4j/util/GathererUtils.java
+++ b/src/main/java/com/ginsberg/gatherers4j/util/GathererUtils.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2024 Todd Ginsberg
+ * Copyright 2025 Todd Ginsberg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,24 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.ginsberg.gatherers4j;
+package com.ginsberg.gatherers4j.util;
 
 import org.jspecify.annotations.Nullable;
 
 import java.util.Comparator;
 import java.util.function.Function;
 
-abstract class GathererUtils {
+abstract public class GathererUtils {
 
-    final static long NANOS_PER_MILLISECOND = 1_000_000;
+    public static final long NANOS_PER_MILLISECOND = 1_000_000;
 
-    static void mustNotBeNull(@Nullable final Object subject, final String message) {
+    public static void mustNotBeNull(@Nullable final Object subject, final String message) {
         if (subject == null) {
             throw new IllegalArgumentException(message);
         }
     }
 
-    static boolean safeEquals(@Nullable final Object left, @Nullable final Object right) {
+    public static boolean safeEquals(@Nullable final Object left, @Nullable final Object right) {
         if (left == null && right == null) {
             return true;
         } else if (left == null || right == null) {
@@ -42,14 +42,14 @@ abstract class GathererUtils {
     // Yes, I realize this is not to contract, but I only want it to measure equality in a narrow case
     // in which I only care about certain outputs.
     @SuppressWarnings("ComparatorMethodParameterNotUsed")
-    static <T> Comparator<T> equalityOnlyComparator() {
+    public static <T> Comparator<T> equalityOnlyComparator() {
         return (o1, o2) -> safeEquals(o1, o2) ? 0 : -1;
     }
 
     // Yes, I realize this is not to contract, but I only want it to measure equality in a narrow case
     // in which I only care about certain outputs.
     @SuppressWarnings("ComparatorMethodParameterNotUsed")
-    static <T,R> Comparator<T> equalityOnlyComparator(final Function<T, R> mappingFunction) {
+    public static <T,R> Comparator<T> equalityOnlyComparator(final Function<T, R> mappingFunction) {
         return (o1, o2) -> safeEquals(mappingFunction.apply(o1), mappingFunction.apply(o2)) ? 0 : -1;
     }
 }

--- a/src/main/java/com/ginsberg/gatherers4j/util/package-info.java
+++ b/src/main/java/com/ginsberg/gatherers4j/util/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Todd Ginsberg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// A library of useful Stream Gatherers (custom intermediate operations) for Java.
+///
+/// @author Todd Ginsberg (todd@ginsberg.com)
+@NullMarked
+package com.ginsberg.gatherers4j.util;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/com/ginsberg/gatherers4j/AccumulatingGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/AccumulatingGathererTest.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.dto.WithIndex;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/ginsberg/gatherers4j/BigDecimalMovingProductGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/BigDecimalMovingProductGathererTest.java
@@ -17,6 +17,7 @@
 package com.ginsberg.gatherers4j;
 
 import com.ginsberg.gatherers4j.dto.WithOriginal;
+import com.ginsberg.gatherers4j.util.TestValueHolder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -25,7 +26,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static com.ginsberg.gatherers4j.TestUtils.BIG_DECIMAL_RECURSIVE_COMPARISON;
+import static com.ginsberg.gatherers4j.util.TestUtils.BIG_DECIMAL_RECURSIVE_COMPARISON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/src/test/java/com/ginsberg/gatherers4j/BigDecimalMovingProductGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/BigDecimalMovingProductGathererTest.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.dto.WithOriginal;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;

--- a/src/test/java/com/ginsberg/gatherers4j/BigDecimalMovingSumGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/BigDecimalMovingSumGathererTest.java
@@ -17,6 +17,7 @@
 package com.ginsberg.gatherers4j;
 
 import com.ginsberg.gatherers4j.dto.WithOriginal;
+import com.ginsberg.gatherers4j.util.TestValueHolder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -25,7 +26,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static com.ginsberg.gatherers4j.TestUtils.BIG_DECIMAL_RECURSIVE_COMPARISON;
+import static com.ginsberg.gatherers4j.util.TestUtils.BIG_DECIMAL_RECURSIVE_COMPARISON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/src/test/java/com/ginsberg/gatherers4j/BigDecimalMovingSumGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/BigDecimalMovingSumGathererTest.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.dto.WithOriginal;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;

--- a/src/test/java/com/ginsberg/gatherers4j/BigDecimalProductGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/BigDecimalProductGathererTest.java
@@ -17,6 +17,7 @@
 package com.ginsberg.gatherers4j;
 
 import com.ginsberg.gatherers4j.dto.WithOriginal;
+import com.ginsberg.gatherers4j.util.TestValueHolder;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;

--- a/src/test/java/com/ginsberg/gatherers4j/BigDecimalProductGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/BigDecimalProductGathererTest.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.dto.WithOriginal;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;

--- a/src/test/java/com/ginsberg/gatherers4j/BigDecimalSimpleAverageGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/BigDecimalSimpleAverageGathererTest.java
@@ -17,6 +17,7 @@
 package com.ginsberg.gatherers4j;
 
 import com.ginsberg.gatherers4j.dto.WithOriginal;
+import com.ginsberg.gatherers4j.util.TestValueHolder;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -24,7 +25,7 @@ import java.math.MathContext;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static com.ginsberg.gatherers4j.TestUtils.BIG_DECIMAL_RECURSIVE_COMPARISON;
+import static com.ginsberg.gatherers4j.util.TestUtils.BIG_DECIMAL_RECURSIVE_COMPARISON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/src/test/java/com/ginsberg/gatherers4j/BigDecimalSimpleAverageGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/BigDecimalSimpleAverageGathererTest.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.dto.WithOriginal;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;

--- a/src/test/java/com/ginsberg/gatherers4j/BigDecimalSimpleMovingAverageGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/BigDecimalSimpleMovingAverageGathererTest.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.dto.WithOriginal;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;

--- a/src/test/java/com/ginsberg/gatherers4j/BigDecimalSimpleMovingAverageGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/BigDecimalSimpleMovingAverageGathererTest.java
@@ -17,6 +17,7 @@
 package com.ginsberg.gatherers4j;
 
 import com.ginsberg.gatherers4j.dto.WithOriginal;
+import com.ginsberg.gatherers4j.util.TestValueHolder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -26,7 +27,7 @@ import java.math.MathContext;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static com.ginsberg.gatherers4j.TestUtils.BIG_DECIMAL_RECURSIVE_COMPARISON;
+import static com.ginsberg.gatherers4j.util.TestUtils.BIG_DECIMAL_RECURSIVE_COMPARISON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/src/test/java/com/ginsberg/gatherers4j/BigDecimalStandardDeviationGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/BigDecimalStandardDeviationGathererTest.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.dto.WithOriginal;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/ginsberg/gatherers4j/BigDecimalStandardDeviationGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/BigDecimalStandardDeviationGathererTest.java
@@ -17,6 +17,7 @@
 package com.ginsberg.gatherers4j;
 
 import com.ginsberg.gatherers4j.dto.WithOriginal;
+import com.ginsberg.gatherers4j.util.TestValueHolder;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +26,7 @@ import java.math.MathContext;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static com.ginsberg.gatherers4j.TestUtils.BIG_DECIMAL_RECURSIVE_COMPARISON;
+import static com.ginsberg.gatherers4j.util.TestUtils.BIG_DECIMAL_RECURSIVE_COMPARISON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/src/test/java/com/ginsberg/gatherers4j/BigDecimalSumGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/BigDecimalSumGathererTest.java
@@ -17,6 +17,7 @@
 package com.ginsberg.gatherers4j;
 
 import com.ginsberg.gatherers4j.dto.WithOriginal;
+import com.ginsberg.gatherers4j.util.TestValueHolder;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;

--- a/src/test/java/com/ginsberg/gatherers4j/BigDecimalSumGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/BigDecimalSumGathererTest.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.dto.WithOriginal;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;

--- a/src/test/java/com/ginsberg/gatherers4j/CrossGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/CrossGathererTest.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.dto.Pair;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/ginsberg/gatherers4j/FrequencyGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/FrequencyGathererTest.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.dto.WithCount;
 import com.ginsberg.gatherers4j.enums.Frequency;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/ginsberg/gatherers4j/GathererUtilsTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/GathererUtilsTest.java
@@ -16,13 +16,14 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.util.GathererUtils;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static com.ginsberg.gatherers4j.GathererUtils.mustNotBeNull;
+import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 import static org.assertj.core.api.Assertions.*;
 
 

--- a/src/test/java/com/ginsberg/gatherers4j/SimpleIndexingGatherersTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/SimpleIndexingGatherersTest.java
@@ -98,16 +98,16 @@ class SimpleIndexingGatherersTest {
             final Stream<String> input = Stream.of("A", "B", "C");
 
             // Act
-            final List<com.ginsberg.gatherers4j.WithIndex<String>> output = input
+            final List<com.ginsberg.gatherers4j.dto.WithIndex<String>> output = input
                     .gather(Gatherers4j.withIndex())
                     .toList();
 
             // Assert
             assertThat(output)
                     .containsExactly(
-                            new com.ginsberg.gatherers4j.WithIndex<>(0, "A"),
-                            new com.ginsberg.gatherers4j.WithIndex<>(1, "B"),
-                            new com.ginsberg.gatherers4j.WithIndex<>(2, "C")
+                            new com.ginsberg.gatherers4j.dto.WithIndex<>(0, "A"),
+                            new com.ginsberg.gatherers4j.dto.WithIndex<>(1, "B"),
+                            new com.ginsberg.gatherers4j.dto.WithIndex<>(2, "C")
                     );
         }
 
@@ -117,16 +117,16 @@ class SimpleIndexingGatherersTest {
             final Stream<Integer> input = Stream.of(1, 2, 3);
 
             // Act
-            final List<com.ginsberg.gatherers4j.WithIndex<Integer>> output = input
+            final List<com.ginsberg.gatherers4j.dto.WithIndex<Integer>> output = input
                     .gather(Gatherers4j.withIndex())
                     .toList();
 
             // Assert
             assertThat(output)
                     .containsExactly(
-                            new com.ginsberg.gatherers4j.WithIndex<>(0, 1),
-                            new com.ginsberg.gatherers4j.WithIndex<>(1, 2),
-                            new com.ginsberg.gatherers4j.WithIndex<>(2, 3)
+                            new com.ginsberg.gatherers4j.dto.WithIndex<>(0, 1),
+                            new com.ginsberg.gatherers4j.dto.WithIndex<>(1, 2),
+                            new com.ginsberg.gatherers4j.dto.WithIndex<>(2, 3)
                     );
         }
     }

--- a/src/test/java/com/ginsberg/gatherers4j/ThrottlingGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/ThrottlingGathererTest.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.util.GathererUtils;
 import org.junit.jupiter.api.Test;
 
 import java.time.Clock;

--- a/src/test/java/com/ginsberg/gatherers4j/ZipWithGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/ZipWithGathererTest.java
@@ -16,6 +16,7 @@
 
 package com.ginsberg.gatherers4j;
 
+import com.ginsberg.gatherers4j.dto.Pair;
 import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;

--- a/src/test/java/com/ginsberg/gatherers4j/util/GathererUtilsTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/util/GathererUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Todd Ginsberg
+ * Copyright 2025 Todd Ginsberg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.ginsberg.gatherers4j;
+package com.ginsberg.gatherers4j.util;
 
-import com.ginsberg.gatherers4j.util.GathererUtils;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/ginsberg/gatherers4j/util/TestUtils.java
+++ b/src/test/java/com/ginsberg/gatherers4j/util/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Todd Ginsberg
+ * Copyright 2025 Todd Ginsberg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,16 @@
  * limitations under the License.
  */
 
-package com.ginsberg.gatherers4j;
+package com.ginsberg.gatherers4j.util;
+
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 
 import java.math.BigDecimal;
 
-public record TestValueHolder(int id, BigDecimal value) {
+public class TestUtils {
+
+    public static final RecursiveComparisonConfiguration BIG_DECIMAL_RECURSIVE_COMPARISON = RecursiveComparisonConfiguration
+            .builder()
+            .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+            .build();
 }

--- a/src/test/java/com/ginsberg/gatherers4j/util/TestValueHolder.java
+++ b/src/test/java/com/ginsberg/gatherers4j/util/TestValueHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Todd Ginsberg
+ * Copyright 2025 Todd Ginsberg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,9 @@
  * limitations under the License.
  */
 
-package com.ginsberg.gatherers4j;
-
-import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
+package com.ginsberg.gatherers4j.util;
 
 import java.math.BigDecimal;
 
-public class TestUtils {
-
-    public static final RecursiveComparisonConfiguration BIG_DECIMAL_RECURSIVE_COMPARISON = RecursiveComparisonConfiguration
-            .builder()
-            .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
-            .build();
+public record TestValueHolder(int id, BigDecimal value) {
 }


### PR DESCRIPTION
One big package is getting messy, move classes into `util` and `dto` where appropriate. Account for JSpecify nullmarked as well.