### PR TITLE
Indexed should be ints, not longs

### DIFF
--- a/docs/gatherers4j/content/changelog/_index.md
+++ b/docs/gatherers4j/content/changelog/_index.md
@@ -9,6 +9,7 @@ no_list: true
 [Released 2025-??-??](https://github.com/tginsberg/gatherers4j/releases/tag/v0.11.0)
 + Fix and document behavior of `window()` when there are multiple partial groupings at the end. Addresses [#135](https://github.com/tginsberg/gatherers4j/issues/135), thanks [@paulk-asert](https://github.com/paulk-asert)!
 + Implement exponential moving averages with `exponentialMovingAverageWithAlpha()`, `exponentialMovingAverageWithAlphaBy()`,`exponentialMovingAverageWithPeriod()`, and `exponentialMovingAverageWithPeriodBy()`,
++ Change index to be an `int` rather than a `long` in `filterIndexed()`, `foldIndexed()`, `mapIndexed()`, `peekIndexed()`, `scanIndexed()` and `withIndex()`. Addresses [#140](https://github.com/tginsberg/gatherers4j/issues/140). 
 
 ## v0.10.0
 [Released 2025-03-19](https://github.com/tginsberg/gatherers4j/releases/tag/v0.10.0)

--- a/docs/gatherers4j/content/gatherers/filtering-and-selection/filterIndexed.md
+++ b/docs/gatherers4j/content/gatherers/filtering-and-selection/filterIndexed.md
@@ -10,9 +10,9 @@ description: Filter a stream according to a given `predicate`, which takes both 
 
 **Signature**
 
-`filterIndexed(BiPredicate<Long, INPUT> predicate)`
+`filterIndexed(BiPredicate<Integer, INPUT> predicate)`
 
-* `predicate` - A non-null `BiPredicate<Long,INPUT>` where the `Long` is the zero-based index of the element being filtered, and the `INPUT` is the element itself.
+* `predicate` - A non-null `BiPredicate<Integer,INPUT>` where the `Integer` is the zero-based index of the element being filtered, and the `INPUT` is the element itself.
 
 ### Examples
 

--- a/docs/gatherers4j/content/gatherers/sequence-operations/foldIndexed.md
+++ b/docs/gatherers4j/content/gatherers/sequence-operations/foldIndexed.md
@@ -19,7 +19,7 @@ the JDK. For a scanning version of this Gatherer, see [`scanIndexed()`](/gathere
 `foldIndexed(Supplier<OUTPUT> initialValue, IndexedAccumulatorFunction<OUTPUT, INPUT, OUTPUT> foldFunction)`
 
 * `initialValue` - A non-null `Supplier` to provide the seed value for the fold (this implementation does not assume the first element is the seed)
-* `foldFunction` - [`IndexedAccumulatorFunction`](https://github.com/tginsberg/gatherers4j/blob/main/src/main/java/com/ginsberg/gatherers4j/IndexedAccumulatorFunction.java) is a variation on a `BiFunction` which injects the `long` index of each element. This function does the actual fold/reduction work.
+* `foldFunction` - [`IndexedAccumulatorFunction`](https://github.com/tginsberg/gatherers4j/blob/main/src/main/java/com/ginsberg/gatherers4j/IndexedAccumulatorFunction.java) is a variation on a `BiFunction` which injects the `int` index of each element. This function does the actual fold/reduction work.
 
 
 

--- a/docs/gatherers4j/content/gatherers/sequence-operations/mapIndexed.md
+++ b/docs/gatherers4j/content/gatherers/sequence-operations/mapIndexed.md
@@ -11,7 +11,7 @@ description: Perform a mapping operation given the element being mapped and its 
 
 **Signature**
 
-`mapIndexed(BiFunction<Long, INPUT, OUTPUT> mappingFunction)`
+`mapIndexed(BiFunction<Integer, INPUT, OUTPUT> mappingFunction)`
 
 * `mappingFunction` - A non-null function to convert input elements and their indexes to output elements.
 

--- a/docs/gatherers4j/content/gatherers/sequence-operations/peekIndexed.md
+++ b/docs/gatherers4j/content/gatherers/sequence-operations/peekIndexed.md
@@ -11,7 +11,7 @@ description: Peek at each element of the stream along with its zero-based index
 
 **Signature**
 
-`peekIndexed(BiConsumer<Long, INPUT> peekingFunction)`
+`peekIndexed(BiConsumer<Integer, INPUT> peekingFunction)`
 
 * `peekingFunction` - A non-null consumer to receive each element and its zero-based index.
 

--- a/docs/gatherers4j/content/gatherers/sequence-operations/scanIndexed.md
+++ b/docs/gatherers4j/content/gatherers/sequence-operations/scanIndexed.md
@@ -18,7 +18,7 @@ the JDK. For a folding version of this Gatherer, see [`foldIndexed()`](/gatherer
 `scanIndexed(Supplier<OUTPUT> initialValue, IndexedAccumulatorFunction<OUTPUT, INPUT, OUTPUT> scanFunction)`
 
 * `initialValue` - A non-null `Supplier` to provide the seed value for the scan (this implementation does not assume the first element is the seed)
-* `scanFunction` - [`IndexedAccumulatorFunction`](https://github.com/tginsberg/gatherers4j/blob/main/src/main/java/com/ginsberg/gatherers4j/IndexedAccumulatorFunction.java) is a variation on a `BiFunction` which injects the `long` index of each element. This function does the actual scan/accumulation work.
+* `scanFunction` - [`IndexedAccumulatorFunction`](https://github.com/tginsberg/gatherers4j/blob/main/src/main/java/com/ginsberg/gatherers4j/IndexedAccumulatorFunction.java) is a variation on a `BiFunction` which injects the `int` index of each element. This function does the actual scan/accumulation work.
 
 
 

--- a/docs/gatherers4j/content/gatherers/sequence-operations/withIndex.md
+++ b/docs/gatherers4j/content/gatherers/sequence-operations/withIndex.md
@@ -9,8 +9,7 @@ description: Maps all elements of the stream as-is along with their 0-based inde
 
 ### Implementation Notes
 
-Each element of the input stream is mapped to a [`WithIndex`](https://github.com/tginsberg/gatherers4j/blob/main/src/main/java/com/ginsberg/gatherers4j/WithIndex.java)record along with its zero-based index. As of now
-does not provide a `mapWithIndex()` functionality but that is on the roadmap.
+Each element of the input stream is mapped to a [`WithIndex`](https://github.com/tginsberg/gatherers4j/blob/main/src/main/java/com/ginsberg/gatherers4j/WithIndex.java)record along with its zero-based index. 
 
 **Signature**
 

--- a/src/main/java/com/ginsberg/gatherers4j/AccumulatingGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/AccumulatingGatherer.java
@@ -71,7 +71,7 @@ public class AccumulatingGatherer<INPUT extends @Nullable Object, OUTPUT extends
     public static class State<OUTPUT> {
         @Nullable
         OUTPUT carriedValue;
-        long index;
+        int index;
 
         private State(@Nullable final OUTPUT initialValue) {
             carriedValue = initialValue;

--- a/src/main/java/com/ginsberg/gatherers4j/Gatherers4j.java
+++ b/src/main/java/com/ginsberg/gatherers4j/Gatherers4j.java
@@ -260,12 +260,12 @@ public abstract class Gatherers4j {
     /// Filter a stream according to the given `predicate`, which takes both the item being examined,
     /// and its index.
     ///
-    /// @param predicate A non-null `BiPredicate<Long,INPUT>` where the `Long` is the zero-based index of the element
+    /// @param predicate A non-null `BiPredicate<Integer,INPUT>` where the `Integer` is the zero-based index of the element
     ///                  being filtered, and the `INPUT` is the element itself.
     /// @param <INPUT>   Type of elements in the input stream
     /// @return A non-null `Gatherer`
     public static <INPUT extends @Nullable Object> Gatherer<INPUT, ?, INPUT> filterIndexed(
-            final BiPredicate<Long, INPUT> predicate
+            final BiPredicate<Integer, INPUT> predicate
     ) {
         return SimpleIndexingGatherers.filterIndexed(predicate);
     }
@@ -414,7 +414,7 @@ public abstract class Gatherers4j {
     /// @param mappingFunction A non-null function to map input to output, given an input and its index
     /// @return A non-null Gatherer
     public static <INPUT extends @Nullable Object, OUTPUT extends @Nullable Object> Gatherer<INPUT, ?, OUTPUT> mapIndexed(
-            final BiFunction<Long, INPUT, OUTPUT> mappingFunction)
+            final BiFunction<Integer, INPUT, OUTPUT> mappingFunction)
     {
         return SimpleIndexingGatherers.mapIndexed(mappingFunction);
     }
@@ -485,7 +485,7 @@ public abstract class Gatherers4j {
     /// @param peekingConsumer A non-null consumer to peek at each element and its index
     /// @return A non-null Gatherer
     public static <INPUT extends @Nullable Object> Gatherer<INPUT, ?, INPUT> peekIndexed(
-            final BiConsumer<Long, INPUT> peekingConsumer)
+            final BiConsumer<Integer, INPUT> peekingConsumer)
     {
         return SimpleIndexingGatherers.peekIndexed(peekingConsumer);
     }

--- a/src/main/java/com/ginsberg/gatherers4j/IndexedAccumulatorFunction.java
+++ b/src/main/java/com/ginsberg/gatherers4j/IndexedAccumulatorFunction.java
@@ -30,5 +30,5 @@ public interface IndexedAccumulatorFunction<
     /// @param carry the accumulated value
     /// @param next  the next value to accumulate
     /// @return the function result
-    R apply(long index, @Nullable A carry, @Nullable B next);
+    R apply(int index, @Nullable A carry, @Nullable B next);
 }

--- a/src/main/java/com/ginsberg/gatherers4j/SimpleIndexingGatherers.java
+++ b/src/main/java/com/ginsberg/gatherers4j/SimpleIndexingGatherers.java
@@ -29,7 +29,7 @@ import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
 public class SimpleIndexingGatherers {
 
     public static <INPUT extends @Nullable Object> Gatherer<INPUT, ?, INPUT> filterIndexed(
-            final BiPredicate<Long, @Nullable INPUT> predicate
+            final BiPredicate<Integer, @Nullable INPUT> predicate
     ) {
         mustNotBeNull(predicate, "Predicate must not be null");
         return Gatherer.ofSequential(
@@ -44,7 +44,7 @@ public class SimpleIndexingGatherers {
     }
 
     public static <INPUT extends @Nullable Object, OUTPUT extends @Nullable Object> Gatherer<INPUT, ?, OUTPUT> mapIndexed(
-            final BiFunction<Long, @Nullable INPUT, @Nullable OUTPUT> mappingFunction
+            final BiFunction<Integer, @Nullable INPUT, @Nullable OUTPUT> mappingFunction
     ) {
         mustNotBeNull(mappingFunction, "mappingFunction must not be null");
         return Gatherer.ofSequential(
@@ -56,7 +56,7 @@ public class SimpleIndexingGatherers {
     }
 
     public static <INPUT extends @Nullable Object> Gatherer<INPUT, ?, INPUT> peekIndexed(
-            final BiConsumer<Long, @Nullable INPUT> peekingConsumer
+            final BiConsumer<Integer, @Nullable INPUT> peekingConsumer
     ) {
         mustNotBeNull(peekingConsumer, "peekingConsumer must not be null");
         return Gatherer.ofSequential(
@@ -74,6 +74,6 @@ public class SimpleIndexingGatherers {
     }
 
     private static class State {
-        long index;
+        int index;
     }
 }

--- a/src/main/java/com/ginsberg/gatherers4j/dto/WithIndex.java
+++ b/src/main/java/com/ginsberg/gatherers4j/dto/WithIndex.java
@@ -19,7 +19,7 @@ package com.ginsberg.gatherers4j.dto;
 import org.jspecify.annotations.Nullable;
 
 public record WithIndex<TYPE>(
-        long index,
+        int index,
         @Nullable TYPE value
 ) {
 }

--- a/src/test/java/com/ginsberg/gatherers4j/BigDecimalExponentialMovingAverageGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/BigDecimalExponentialMovingAverageGathererTest.java
@@ -130,7 +130,7 @@ class BigDecimalExponentialMovingAverageGathererTest {
         // Arrange
         final Stream<TestValueHolder> input = Stream.of("10.5", "15.2", "8.7", "12.0", "9.8")
                 .map(BigDecimal::new)
-                .map(it -> new TestValueHolder(0, it));
+                .gather(Gatherers4j.mapIndexed(TestValueHolder::new));
 
         // Act
         final List<BigDecimal> output = input


### PR DESCRIPTION
+ The odds that somebody will have a 2^32 length stream are remote, and the most common case should be the easiest to implement