### PR TITLE
Optimize left rotations

### DIFF
--- a/docs/gatherers4j/content/changelog/_index.md
+++ b/docs/gatherers4j/content/changelog/_index.md
@@ -8,8 +8,9 @@ no_list: true
 ## v0.11.0
 [Released 2025-??-??](https://github.com/tginsberg/gatherers4j/releases/tag/v0.11.0)
 + Fix and document behavior of `window()` when there are multiple partial groupings at the end. Addresses [#135](https://github.com/tginsberg/gatherers4j/issues/135), thanks [@paulk-asert](https://github.com/paulk-asert)!
-+ Implement exponential moving averages with `exponentialMovingAverageWithAlpha()`, `exponentialMovingAverageWithAlphaBy()`,`exponentialMovingAverageWithPeriod()`, and `exponentialMovingAverageWithPeriodBy()`,
++ Implement exponential moving averages with `exponentialMovingAverageWithAlpha()`, `exponentialMovingAverageWithAlphaBy()`,`exponentialMovingAverageWithPeriod()`, and `exponentialMovingAverageWithPeriodBy()`.
 + Change index to be an `int` rather than a `long` in `filterIndexed()`, `foldIndexed()`, `mapIndexed()`, `peekIndexed()`, `scanIndexed()` and `withIndex()`. Addresses [#140](https://github.com/tginsberg/gatherers4j/issues/140). 
++ Optimize `rotate(Left)` to store a minimal set of elements instead of the entire stream. Addresses [#141](https://github.com/tginsberg/gatherers4j/issues/141), thanks [@paulk-asert](https://github.com/paulk-asert)! 
 
 ## v0.10.0
 [Released 2025-03-19](https://github.com/tginsberg/gatherers4j/releases/tag/v0.10.0)

--- a/docs/gatherers4j/content/gatherers/sequence-operations/rotate.md
+++ b/docs/gatherers4j/content/gatherers/sequence-operations/rotate.md
@@ -10,6 +10,7 @@ description: Consume the entire stream and emit its elements rotated either left
 ### Implementation Notes
 
 This implementation reads the entire stream before emitting any results making it inappropriate for infinite streams.
+Left rotations store `abs(distance)` number of elements while right rotations store the entire stream.
 
 **Signature**
 

--- a/src/main/java/com/ginsberg/gatherers4j/RotateGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/RotateGatherer.java
@@ -51,6 +51,8 @@ public class RotateGatherer<INPUT extends @Nullable Object>
         return Integrator.ofGreedy((state, element, downstream) -> {
             if (distance == 0) {
                 downstream.push(element);
+            } else if(direction == Rotate.Left && state.fullStream.size() == distance) {
+                downstream.push(element);
             } else {
                 state.fullStream.add(element);
             }

--- a/src/test/java/com/ginsberg/gatherers4j/RotateGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/RotateGathererTest.java
@@ -70,11 +70,13 @@ class RotateGathererTest {
                     Arguments.arguments(3, List.of("D", "E", "A", "B", "C")),
                     Arguments.arguments(4, List.of("E", "A", "B", "C", "D")),
                     Arguments.arguments(5, List.of("A", "B", "C", "D", "E")),
+                    Arguments.arguments(6, List.of("B", "C", "D", "E", "A")),
                     Arguments.arguments(-1, List.of("E", "A", "B", "C", "D")),
                     Arguments.arguments(-2, List.of("D", "E", "A", "B", "C")),
                     Arguments.arguments(-3, List.of("C", "D", "E", "A", "B")),
                     Arguments.arguments(-4, List.of("B", "C", "D", "E", "A")),
-                    Arguments.arguments(-5, List.of("A", "B", "C", "D", "E"))
+                    Arguments.arguments(-5, List.of("A", "B", "C", "D", "E")),
+                    Arguments.arguments(-6, List.of("E", "A", "B", "C", "D"))
             );
         }
 


### PR DESCRIPTION
When rotating left, we can store `distance` number of elements rather than the entire stream as an optimization.

Addresses #141 