### PR TITLE
Upgrade Dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     id("java-library")
     id("org.jreleaser") version "1.18.0"
     id("maven-publish")
-    id("net.ltgt.errorprone") version "4.1.0"
+    id("net.ltgt.errorprone") version "4.2.0"
     id("signing")
 }
 
@@ -43,15 +43,15 @@ dependencies {
     testImplementation("org.apache.commons:commons-statistics-inference:1.1") {
         because("We use this to measure if random sampling methods actually work")
     }
-    testImplementation("org.junit.jupiter:junit-jupiter:5.12.0") {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.13.1") {
         because("We need this to run tests")
     }
-    testImplementation("org.assertj:assertj-core:3.27.2") {
+    testImplementation("org.assertj:assertj-core:3.27.3") {
         because("These assertions are clearer than JUnit+Hamcrest")
     }
 
-    errorprone("com.google.errorprone:error_prone_core:2.36.0")
-    errorprone("com.uber.nullaway:nullaway:0.12.3")
+    errorprone("com.google.errorprone:error_prone_core:2.38.0")
+    errorprone("com.uber.nullaway:nullaway:0.12.7")
 }
 
 jreleaser {
@@ -119,7 +119,7 @@ publishing {
                 licenses {
                     license {
                         name = "The Apache License, Version 2.0"
-                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                        url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
                     }
                 }
                 developers {
@@ -146,7 +146,6 @@ publishing {
 
 signing {
     useInMemoryPgpKeys(
-        // local: file("../g4jkey.asc").readText(),
         System.getenv("SONATYPE_SIGNING_KEY"),
         System.getenv("SONATYPE_SIGNING_PASSPHRASE")
     )

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
+ Upgrade Gradle from 8.14 to 8.14.2
+ Upgrade Errorprone gradle plugin from 4.1.0 to 4.2.0
+ Upgrade JUnit Jupiter from 5.12.0 to 5.13.1
+ Upgrade AssertJ from 3.27.2 to 3.27.3
+ Upgrade ErrorProne Core from 2.36.0 to 2.38.0
+ Upgrade Errorprone Nullaway from 0.12.3 to 0.12.7
+ Fix license url from http to https in pom generation