### PR TITLE
JUnit extension to create Sequential and Parallel streams for the same set of inputs

### DIFF
--- a/src/main/java/com/ginsberg/gatherers4j/DedupeConsecutiveGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/DedupeConsecutiveGatherer.java
@@ -17,11 +17,10 @@ package com.ginsberg.gatherers4j;
 
 import org.jspecify.annotations.Nullable;
 
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Gatherer;
-
-import static com.ginsberg.gatherers4j.util.GathererUtils.safeEquals;
 
 public class DedupeConsecutiveGatherer<INPUT extends @Nullable Object>
         implements Gatherer<INPUT, DedupeConsecutiveGatherer.State, INPUT> {
@@ -50,7 +49,7 @@ public class DedupeConsecutiveGatherer<INPUT extends @Nullable Object>
                 state.hasValue = true;
                 state.value = mapped;
                 return downstream.push(element);
-            } else if (!safeEquals(state.value, mapped)) {
+            } else if (!Objects.equals(state.value, mapped)) {
                 state.value = mapped;
                 return downstream.push(element);
             }

--- a/src/main/java/com/ginsberg/gatherers4j/util/GathererUtils.java
+++ b/src/main/java/com/ginsberg/gatherers4j/util/GathererUtils.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Gatherer;
 import java.util.stream.Stream;
@@ -35,27 +36,18 @@ abstract public class GathererUtils {
         }
     }
 
-    public static boolean safeEquals(@Nullable final Object left, @Nullable final Object right) {
-        if (left == null && right == null) {
-            return true;
-        } else if (left == null || right == null) {
-            return false;
-        }
-        return left.equals(right);
-    }
-
     // Yes, I realize this is not to contract, but I only want it to measure equality in a narrow case
     // in which I only care about certain outputs.
     @SuppressWarnings("ComparatorMethodParameterNotUsed")
     public static <T> Comparator<T> equalityOnlyComparator() {
-        return (o1, o2) -> safeEquals(o1, o2) ? 0 : -1;
+        return (o1, o2) -> Objects.equals(o1, o2) ? 0 : -1;
     }
 
     // Yes, I realize this is not to contract, but I only want it to measure equality in a narrow case
     // in which I only care about certain outputs.
     @SuppressWarnings("ComparatorMethodParameterNotUsed")
     public static <T, R> Comparator<T> equalityOnlyComparator(final Function<T, R> mappingFunction) {
-        return (o1, o2) -> safeEquals(mappingFunction.apply(o1), mappingFunction.apply(o2)) ? 0 : -1;
+        return (o1, o2) -> Objects.equals(mappingFunction.apply(o1), mappingFunction.apply(o2)) ? 0 : -1;
     }
 
     // Push all elements in the collection to the downstream, taking care to listen for a stop signal.

--- a/src/test/java/com/ginsberg/gatherers4j/FrequencyGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/FrequencyGathererTest.java
@@ -18,6 +18,7 @@ package com.ginsberg.gatherers4j;
 
 import com.ginsberg.gatherers4j.dto.WithCount;
 import com.ginsberg.gatherers4j.enums.Frequency;
+import com.ginsberg.gatherers4j.test.ParallelAndSequentialTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -28,11 +29,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class FrequencyGathererTest {
 
-    @Test
-    void ascending() {
-        // Arrange
-        final Stream<String> input = Stream.of("A", "A", "A", "B", "B", "B", "B", "C", "C");
-
+    @ParallelAndSequentialTest(values = {"A", "A", "A", "B", "B", "B", "B", "C", "C"})
+    void ascending(final Stream<String> input) {
         // Act
         final List<WithCount<String>> output = input.gather(Gatherers4j.orderByFrequency(Frequency.Ascending)).toList();
 
@@ -45,47 +43,12 @@ class FrequencyGathererTest {
                 );
     }
 
-    @Test
-    void ascendingParallel() {
-        // Arrange
-        final Stream<String> input = Stream.of("A", "A", "A", "B", "B", "B", "B", "C", "C");
 
-        // Act
-        final List<WithCount<String>> output = input.parallel().gather(Gatherers4j.orderByFrequency(Frequency.Ascending)).toList();
-
-        // Assert
-        assertThat(output)
-                .containsExactly(
-                        new WithCount<>("C", 2),
-                        new WithCount<>("A", 3),
-                        new WithCount<>("B", 4)
-                );
-    }
-
-    @Test
-    void descending() {
-        // Arrange
-        final Stream<String> input = Stream.of("A", "A", "A", "B", "B", "B", "B", "C", "C");
+    @ParallelAndSequentialTest(values = {"A", "A", "A", "B", "B", "B", "B", "C", "C"})
+    void descending(final Stream<String> input) {
 
         // Act
         final List<WithCount<String>> output = input.gather(Gatherers4j.orderByFrequency(Frequency.Descending)).toList();
-
-        // Assert
-        assertThat(output)
-                .containsExactly(
-                        new WithCount<>("B", 4),
-                        new WithCount<>("A", 3),
-                        new WithCount<>("C", 2)
-                );
-    }
-
-    @Test
-    void descendingParallel() {
-        // Arrange
-        final Stream<String> input = Stream.of("A", "A", "A", "B", "B", "B", "B", "C", "C");
-
-        // Act
-        final List<WithCount<String>> output = input.parallel().gather(Gatherers4j.orderByFrequency(Frequency.Descending)).toList();
 
         // Assert
         assertThat(output)

--- a/src/test/java/com/ginsberg/gatherers4j/test/ParallelAndSequentialTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/test/ParallelAndSequentialTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 Todd Ginsberg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ginsberg.gatherers4j.test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ParameterizedTest
+@ArgumentsSource(StreamSourceArgumentProvider.class)
+public @interface ParallelAndSequentialTest {
+
+    String NULL = "__CONSTANT_NULL_MARKER-c864be71-3232-48aa-9c1e-dff5a14b622c__";
+
+    StreamElementType type() default StreamElementType.String;
+
+    String[] values() default {};
+
+
+}

--- a/src/test/java/com/ginsberg/gatherers4j/test/StreamElementType.java
+++ b/src/test/java/com/ginsberg/gatherers4j/test/StreamElementType.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 Todd Ginsberg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ginsberg.gatherers4j.test;
+
+import java.util.function.Function;
+
+public enum StreamElementType {
+    BigDecimal(java.math.BigDecimal::new),
+    String(it -> it);
+
+    final Function<String, Object> mapper;
+
+    StreamElementType(final Function<String, Object> mapper) {
+        this.mapper = mapper;
+    }
+}

--- a/src/test/java/com/ginsberg/gatherers4j/test/StreamSourceArgumentProvider.java
+++ b/src/test/java/com/ginsberg/gatherers4j/test/StreamSourceArgumentProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 Todd Ginsberg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ginsberg.gatherers4j.test;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.AnnotationConsumer;
+import org.junit.jupiter.params.support.ParameterDeclarations;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static com.ginsberg.gatherers4j.test.ParallelAndSequentialTest.NULL;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class StreamSourceArgumentProvider
+        implements ArgumentsProvider, AnnotationConsumer<ParallelAndSequentialTest> {
+
+    private Object[] array;
+
+    @Override
+    public void accept(final ParallelAndSequentialTest streamSource) {
+        this.array = Arrays
+                .stream(streamSource.values())
+                .map(it -> Objects.equals(it, NULL) ? null : streamSource.type().mapper.apply(it))
+                .toArray();
+    }
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(
+            final ParameterDeclarations parameterDeclarations,
+            final ExtensionContext context
+    ) {
+        return Stream.of(
+                arguments(named("Sequential", Arrays.stream(array))),
+                arguments(named("Parallel", Arrays.stream(array).parallel()))
+        );
+    }
+}

--- a/src/test/java/com/ginsberg/gatherers4j/test/StreamType.java
+++ b/src/test/java/com/ginsberg/gatherers4j/test/StreamType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 Todd Ginsberg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ginsberg.gatherers4j.test;
+
+public enum StreamType {
+    Parallel,
+    Sequential
+}

--- a/src/test/java/com/ginsberg/gatherers4j/util/GathererUtilsTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/util/GathererUtilsTest.java
@@ -23,7 +23,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.ginsberg.gatherers4j.util.GathererUtils.mustNotBeNull;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 class GathererUtilsTest {
@@ -72,35 +74,4 @@ class GathererUtilsTest {
             assertThatNoException().isThrownBy(() -> mustNotBeNull("NonNull", "123"));
         }
     }
-
-    @SuppressWarnings("ConstantValue")
-    @Nested
-    class SafeEquals {
-
-        @Test
-        void withTwoNulls() {
-            assertThat(GathererUtils.safeEquals(null, null)).isTrue();
-        }
-
-        @Test
-        void withTwoNonNullsThatAreEqual() {
-            assertThat(GathererUtils.safeEquals("A", "A")).isTrue();
-        }
-
-        @Test
-        void withTwoNonNullsThatAreNotEqual() {
-            assertThat(GathererUtils.safeEquals("A", "B")).isFalse();
-        }
-
-        @Test
-        void withLeftNullRightNotNull() {
-            assertThat(GathererUtils.safeEquals(null, "A")).isFalse();
-        }
-
-        @Test
-        void withLeftNotNullRightNull() {
-            assertThat(GathererUtils.safeEquals("A", null)).isFalse();
-        }
-    }
-
 }


### PR DESCRIPTION
+ Also, Objects.equals() replacing GathererUtils.safeEquals()