### PR TITLE
Upgrade project dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: gradle/actions/wrapper-validation@v4
 
       - name: Set up JDK 24
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '24'
           distribution: 'temurin'
@@ -29,7 +29,7 @@ jobs:
       - name: Add coverage to PR
         if: github.event_name == 'pull_request'
         id: jacoco
-        uses: madrapps/jacoco-report@v1.6.1
+        uses: madrapps/jacoco-report@v1.7.2
         with:
           paths: ${{ github.workspace }}/**/build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           submodules: true
           fetch-depth: 0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,12 +11,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: gradle/actions/wrapper-validation@v4
 
       - name: Set up JDK 24
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '24'
           distribution: 'temurin'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("com.adarshr.test-logger") version "4.0.0"
     id("jacoco")
     id("java-library")
-    id("org.jreleaser") version "1.19.0"
+    id("org.jreleaser") version "1.20.0"
     id("maven-publish")
     id("net.ltgt.errorprone") version "4.3.0"
     id("signing")
@@ -36,7 +36,8 @@ dependencies {
     api("org.jspecify:jspecify:1.0.0") {
         because("Annotating with JSpecify makes static analysis more accurate")
     }
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher") {
+
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.13.4") {
         because("Starting in Gradle 9.0, this needs to be an explicitly declared dependency")
     }
 
@@ -46,12 +47,16 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:5.13.4") {
         because("We need this to run tests")
     }
-    testImplementation("org.assertj:assertj-core:3.27.3") {
+    testImplementation("org.assertj:assertj-core:3.27.4") {
         because("These assertions are clearer than JUnit+Hamcrest")
     }
 
-    errorprone("com.google.errorprone:error_prone_core:2.41.0")
-    errorprone("com.uber.nullaway:nullaway:0.12.7")
+    errorprone("com.google.errorprone:error_prone_core:2.41.0") {
+        because("This helps us eliminate bugs during the development cycle")
+    }
+    errorprone("com.uber.nullaway:nullaway:0.12.9") {
+        because("It helps us find nullability issues, along with JSpecify")
+    }
 }
 
 jreleaser {


### PR DESCRIPTION
Upgrade various dependencies to their latest versions:

- Upgraded `actions/checkout` from `v2/v4` to `v5`
- Upgraded `actions/setup-java` from `v4` to `v5`
- Upgraded `madrapps/jacoco-report` from `v1.6.1` to `v1.7.2`
- Upgraded Gradle plugin `org.jreleaser` from `1.19.0` to `1.20.0`
- Upgraded Gradle plugin `errorprone Nullaway` from `0.12.7` to `0.12.9`
- Upgraded `AssertJ` from `3.27.3` to `3.27.4`
- Added explicit dependency for `junit-platform-launcher` at `1.13.4`.