### PR TITLE
#164 - Upgrade to Java 25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
 
       - uses: gradle/actions/wrapper-validation@v4
 
-      - name: Set up JDK 24
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
 
       - uses: gradle/actions/wrapper-validation@v4
 
-      - name: Set up JDK 24
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gatherers4j
 
-A library of useful [Stream Gatherers](https://openjdk.org/jeps/485) (custom intermediate operations) for Java 24+.
+A library of useful [Stream Gatherers](https://openjdk.org/jeps/485) (custom intermediate operations) for Java 25+.
 
 See [the full set of documentation](https://tginsberg.github.io/gatherers4j/) for information on how to use Gatherers4j.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ else "${gitBranch.substringAfterLast("/")}-SNAPSHOT"
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(24)
+        languageVersion = JavaLanguageVersion.of(25)
     }
     withJavadocJar()
     withSourcesJar()
@@ -41,20 +41,20 @@ dependencies {
         because("Starting in Gradle 9.0, this needs to be an explicitly declared dependency")
     }
 
-    testImplementation("org.apache.commons:commons-statistics-inference:1.1") {
+    testImplementation("org.apache.commons:commons-statistics-inference:1.2") {
         because("We use this to measure if random sampling methods actually work")
     }
     testImplementation("org.junit.jupiter:junit-jupiter:5.13.4") {
         because("We need this to run tests")
     }
-    testImplementation("org.assertj:assertj-core:3.27.4") {
+    testImplementation("org.assertj:assertj-core:3.27.5") {
         because("These assertions are clearer than JUnit+Hamcrest")
     }
 
-    errorprone("com.google.errorprone:error_prone_core:2.41.0") {
+    errorprone("com.google.errorprone:error_prone_core:2.42.0") {
         because("This helps us eliminate bugs during the development cycle")
     }
-    errorprone("com.uber.nullaway:nullaway:0.12.9") {
+    errorprone("com.uber.nullaway:nullaway:0.12.10") {
         because("It helps us find nullability issues, along with JSpecify")
     }
 }

--- a/docs/gatherers4j/content/changelog/_index.md
+++ b/docs/gatherers4j/content/changelog/_index.md
@@ -7,6 +7,7 @@ no_list: true
 
 ## v0.12.0
 [Released 2025-??-??](https://github.com/tginsberg/gatherers4j/releases/tag/v0.12.0)
++ Move target Java version to 25 (was 24) Addresses [#164](https://github.com/tginsberg/gatherers4j/issues/164)
 + Support Java Modularization. Addresses [#156](https://github.com/tginsberg/gatherers4j/issues/156), thanks [@Goldmensch](https://github.com/Goldmensch)! 
 + Support parallelization in UniquelyOccurringGatherer
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/test/java/com/ginsberg/gatherers4j/test/StreamElementType.java
+++ b/src/test/java/com/ginsberg/gatherers4j/test/StreamElementType.java
@@ -16,15 +16,18 @@
 
 package com.ginsberg.gatherers4j.test;
 
-import java.util.function.Function;
+import java.math.BigDecimal;
 
 public enum StreamElementType {
-    BigDecimal(java.math.BigDecimal::new),
-    String(it -> it);
+    BigDecimal {
+        @Override
+        public Object applyMapper(final String input) {
+            return new BigDecimal(input);
+        }
+    },
+    String;
 
-    final Function<String, Object> mapper;
-
-    StreamElementType(final Function<String, Object> mapper) {
-        this.mapper = mapper;
+    public Object applyMapper(final String input) {
+        return input;
     }
 }

--- a/src/test/java/com/ginsberg/gatherers4j/test/StreamSourceArgumentProvider.java
+++ b/src/test/java/com/ginsberg/gatherers4j/test/StreamSourceArgumentProvider.java
@@ -39,7 +39,7 @@ public class StreamSourceArgumentProvider
     public void accept(final ParallelAndSequentialTest streamSource) {
         this.array = Arrays
                 .stream(streamSource.values())
-                .map(it -> Objects.equals(it, NULL) ? null : streamSource.type().mapper.apply(it))
+                .map(it -> Objects.equals(it, NULL) ? null : streamSource.type().applyMapper(it))
                 .toArray();
     }
 


### PR DESCRIPTION
- Upgrade JDK from 24 to 25 in workflows and build config
- Upgrade Gradle from 9.0.0 to 9.1.0
- Upgrade commons-statistics-inference from 1.1 to 1.2
- Upgrade AssertJ from 3.27.4 to 3.27.5
- Upgrade ErrorProne Core from 2.41.0 to 2.42.0
- Upgrade Nullaway from 0.12.9 to 0.12.10
- Refactor StreamElementType to remove Function usage and improve flow readability because ErrorProne cannot determine if the function is immutable or not