### PR TITLE
Upgrade Dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024-2025 Todd Ginsberg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import net.ltgt.gradle.errorprone.CheckSeverity
 import net.ltgt.gradle.errorprone.errorprone
 import java.io.IOException
@@ -6,7 +22,7 @@ plugins {
     id("com.adarshr.test-logger") version "4.0.0"
     id("jacoco")
     id("java-library")
-    id("org.jreleaser") version "1.20.0"
+    id("org.jreleaser") version "1.22.0"
     id("maven-publish")
     id("me.champeau.jmh") version "0.7.3"
     id("net.ltgt.errorprone") version "4.3.0"
@@ -16,6 +32,8 @@ plugins {
 description = "An extra set of helpful Stream Gatherers for Java"
 group = "com.ginsberg"
 version = file("VERSION.txt").readLines().first()
+
+val jUnitVersion = "6.0.1"
 
 val gitBranch = gitBranch()
 val gatherers4jVersion = if (gitBranch == "main" || gitBranch.startsWith("release/")) version.toString()
@@ -38,24 +56,24 @@ dependencies {
         because("Annotating with JSpecify makes static analysis more accurate")
     }
 
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.13.4") {
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:$jUnitVersion") {
         because("Starting in Gradle 9.0, this needs to be an explicitly declared dependency")
     }
 
     testImplementation("org.apache.commons:commons-statistics-inference:1.2") {
         because("We use this to measure if random sampling methods actually work")
     }
-    testImplementation("org.junit.jupiter:junit-jupiter:6.0.0") {
+    testImplementation("org.junit.jupiter:junit-jupiter:$jUnitVersion") {
         because("We need this to run tests")
     }
-    testImplementation("org.assertj:assertj-core:3.27.5") {
+    testImplementation("org.assertj:assertj-core:3.27.6") {
         because("These assertions are clearer than JUnit+Hamcrest")
     }
 
-    errorprone("com.google.errorprone:error_prone_core:2.42.0") {
+    errorprone("com.google.errorprone:error_prone_core:2.45.0") {
         because("This helps us eliminate bugs during the development cycle")
     }
-    errorprone("com.uber.nullaway:nullaway:0.12.10") {
+    errorprone("com.uber.nullaway:nullaway:0.12.15") {
         because("It helps us find nullability issues, along with JSpecify")
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,22 @@
+#
+# Copyright 2024-2025 Todd Ginsberg
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Upgrade Gradle from 9.1.0 to 9.2.1
- Upgrade org.jreleaser from 1.20.0 to 1.22.0
- Upgrade JUnit to from 6.0.0 to 6.0.1
- Upgrade assertj-core from 3.27.5 to 3.27.6
- Upgrade error_prone_core from 2.42.0 to 2.45.0
- Upgrade nullaway from 0.12.10 to 0.12.15