### PR TITLE
Refactor tests to use convenient AssertJ exception assertions

### DIFF
--- a/src/test/java/com/ginsberg/gatherers4j/AccumulatingGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/AccumulatingGathererTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 public class AccumulatingGathererTest {
 
@@ -34,8 +34,9 @@ public class AccumulatingGathererTest {
         @Test
         @SuppressWarnings("DataFlowIssue")
         void accumulatorFunctionMustNotBeNull() {
-            assertThatThrownBy(() -> Gatherers4j.foldIndexed(() -> "A", null))
-                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatIllegalArgumentException()
+                .isThrownBy(() -> Gatherers4j.foldIndexed(() -> "A", null))
+                .withMessage("Accumulator function must not be null");
         }
 
         @Test
@@ -71,8 +72,9 @@ public class AccumulatingGathererTest {
         @Test
         @SuppressWarnings("DataFlowIssue")
         void initialSupplierMustNotBeNull() {
-            assertThatThrownBy(() -> Gatherers4j.foldIndexed(null, (_, _, it) -> it))
-                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatIllegalArgumentException()
+                .isThrownBy(() -> Gatherers4j.foldIndexed(null, (_, _, it) -> it))
+                .withMessage("Initial value supplier must not be null");
         }
     }
 
@@ -81,13 +83,17 @@ public class AccumulatingGathererTest {
         @Test
         @SuppressWarnings("DataFlowIssue")
         void initialValueMustNotBeNull() {
-            assertThatThrownBy(() -> Gatherers4j.scanIndexed(null, (_, _, _) -> 0)).isInstanceOf(IllegalArgumentException.class);
+            assertThatIllegalArgumentException()
+                .isThrownBy(() -> Gatherers4j.scanIndexed(null, (_, _, _) -> 0))
+                .withMessage("Initial value supplier must not be null");
         }
 
         @Test
         @SuppressWarnings("DataFlowIssue")
         void scanIndexFunctionMustNotBeNull() {
-            assertThatThrownBy(() -> Gatherers4j.scanIndexed(() -> "", null)).isInstanceOf(IllegalArgumentException.class);
+            assertThatIllegalArgumentException()
+                .isThrownBy(() -> Gatherers4j.scanIndexed(() -> "", null))
+                .withMessage("Accumulator function must not be null");
         }
 
         @Test

--- a/src/test/java/com/ginsberg/gatherers4j/CrossGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/CrossGathererTest.java
@@ -16,18 +16,18 @@
 
 package com.ginsberg.gatherers4j;
 
-import com.ginsberg.gatherers4j.dto.Pair;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import static com.ginsberg.gatherers4j.Gatherers4j.crossWith;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
+import com.ginsberg.gatherers4j.dto.Pair;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
-
-import static java.util.Collections.emptyList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 class CrossGathererTest {
 
@@ -36,7 +36,9 @@ class CrossGathererTest {
         @Test
         @SuppressWarnings("DataFlowIssue")
         void crossIterableMustNotBeNull() {
-            assertThatThrownBy(() -> Gatherers4j.crossWith((Iterable<String>) null)).isInstanceOf(IllegalArgumentException.class);
+            assertThatIllegalArgumentException()
+                .isThrownBy(() -> crossWith((Iterable<String>) null))
+                .withMessage("source list must not be null");
         }
 
         @Test
@@ -102,7 +104,9 @@ class CrossGathererTest {
         @Test
         @SuppressWarnings("DataFlowIssue")
         void crossIteratorMustNotBeNull() {
-            assertThatThrownBy(() -> Gatherers4j.crossWith((Iterator<String>) null)).isInstanceOf(IllegalArgumentException.class);
+            assertThatIllegalArgumentException()
+                .isThrownBy(() -> crossWith((Iterator<String>) null))
+                .withMessage("source iterator must not be null");
         }
 
         @Test
@@ -168,7 +172,9 @@ class CrossGathererTest {
         @Test
         @SuppressWarnings("DataFlowIssue")
         void crossStreamMustNotBeNull() {
-            assertThatThrownBy(() -> Gatherers4j.crossWith((Stream<String>) null)).isInstanceOf(IllegalArgumentException.class);
+            assertThatIllegalArgumentException()
+                .isThrownBy(() -> crossWith((Stream<String>) null))
+                .withMessage("source stream must not be null");
         }
 
         @Test
@@ -235,7 +241,9 @@ class CrossGathererTest {
         @Test
         @SuppressWarnings("DataFlowIssue")
         void crossVarargsNotBeNull() {
-            assertThatThrownBy(() -> Gatherers4j.crossWith((String[]) null)).isInstanceOf(IllegalArgumentException.class);
+            assertThatIllegalArgumentException()
+                .isThrownBy(() -> crossWith((String[]) null))
+                .withMessage("source must not be null");
         }
 
         @Test

--- a/src/test/java/com/ginsberg/gatherers4j/DropLastGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/DropLastGathererTest.java
@@ -22,15 +22,15 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 class DropLastGathererTest {
 
     @Test
     void countMustBePositive() {
-        assertThatThrownBy(() -> Stream.of("A")
-                .gather(Gatherers4j.dropLast(0)).toList())
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> Gatherers4j.dropLast(0))
+            .withMessage("DropLast count must be positive");
     }
 
     @Test

--- a/src/test/java/com/ginsberg/gatherers4j/EveryNthTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/EveryNthTest.java
@@ -16,14 +16,15 @@
 
 package com.ginsberg.gatherers4j;
 
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import static com.ginsberg.gatherers4j.Gatherers4j.dropEveryNth;
+import static com.ginsberg.gatherers4j.Gatherers4j.takeEveryNth;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import java.util.List;
 import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 class EveryNthTest {
 
@@ -44,13 +45,13 @@ class EveryNthTest {
 
         @Test
         void countMustBeTwoOrGreater() {
-            assertThatThrownBy(() ->
-                    Stream.of("A").gather(Gatherers4j.dropEveryNth(0)).toList()
-            ).isInstanceOf(IllegalArgumentException.class);
+            assertThatIllegalArgumentException()
+                .isThrownBy(() -> dropEveryNth(0))
+                .withMessage("Count must be a minimum of 2");
 
-            assertThatThrownBy(() ->
-                    Stream.of("A").gather(Gatherers4j.dropEveryNth(1)).toList()
-            ).isInstanceOf(IllegalArgumentException.class);
+            assertThatIllegalArgumentException()
+                .isThrownBy(() -> dropEveryNth(1))
+                .withMessage("Count must be a minimum of 2");
         }
     }
 
@@ -71,13 +72,13 @@ class EveryNthTest {
 
         @Test
         void countMustBeTwoOrGreater() {
-            assertThatThrownBy(() ->
-                    Stream.of("A").gather(Gatherers4j.takeEveryNth(0)).toList()
-            ).isInstanceOf(IllegalArgumentException.class);
+            assertThatIllegalArgumentException()
+                .isThrownBy(() -> takeEveryNth(0))
+                .withMessage("Count must be a minimum of 2");
 
-            assertThatThrownBy(() ->
-                    Stream.of("A").gather(Gatherers4j.takeEveryNth(1)).toList()
-            ).isInstanceOf(IllegalArgumentException.class);
+            assertThatIllegalArgumentException()
+                .isThrownBy(() -> takeEveryNth(1))
+                .withMessage("Count must be a minimum of 2");
         }
     }
 

--- a/src/test/java/com/ginsberg/gatherers4j/FrequencyGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/FrequencyGathererTest.java
@@ -16,16 +16,15 @@
 
 package com.ginsberg.gatherers4j;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
 import com.ginsberg.gatherers4j.dto.WithCount;
 import com.ginsberg.gatherers4j.enums.Frequency;
 import com.ginsberg.gatherers4j.test.ParallelAndSequentialTest;
-import org.junit.jupiter.api.Test;
-
 import java.util.List;
 import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.Test;
 
 class FrequencyGathererTest {
 
@@ -61,9 +60,9 @@ class FrequencyGathererTest {
 
     @Test
     void orderMustBeSpecified() {
-        assertThatThrownBy(() ->
-                Stream.of("A").gather(new FrequencyGatherer<>(null)).toList()
-        ).isInstanceOf(IllegalArgumentException.class);
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> new FrequencyGatherer<>(null))
+            .withMessage("Order must be specified");
     }
 
 }

--- a/src/test/java/com/ginsberg/gatherers4j/GroupChangingGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/GroupChangingGathererTest.java
@@ -16,17 +16,19 @@
 
 package com.ginsberg.gatherers4j;
 
-import com.ginsberg.gatherers4j.enums.Order;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import static com.ginsberg.gatherers4j.Gatherers4j.groupBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.ginsberg.gatherers4j.enums.Order;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 class GroupChangingGathererTest {
 
@@ -135,7 +137,9 @@ class GroupChangingGathererTest {
         @SuppressWarnings("DataFlowIssue")
         @Test
         void mappingFunctionMustNotBeNull() {
-            assertThatThrownBy(() -> Gatherers4j.groupBy(null)).isInstanceOf(IllegalArgumentException.class);
+            assertThatIllegalArgumentException()
+                .isThrownBy(() -> groupBy(null))
+                .withMessage("mappingFunction must not be null");
         }
 
         @Test
@@ -222,9 +226,10 @@ class GroupChangingGathererTest {
 
             @Test
             void ensureDescendingFailureCase() {
-                assertThatThrownBy(() ->
+                assertThatIllegalStateException()
+                    .isThrownBy(() ->
                         Stream.of(1, 1).gather(Gatherers4j.ensureOrdered(Order.Descending)).toList()
-                ).isExactlyInstanceOf(IllegalStateException.class);
+                    ).withMessage("Elements not in proper order: Descending");
             }
 
             @Test

--- a/src/test/java/com/ginsberg/gatherers4j/GroupChangingGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/GroupChangingGathererTest.java
@@ -229,7 +229,8 @@ class GroupChangingGathererTest {
                 assertThatIllegalStateException()
                     .isThrownBy(() ->
                         Stream.of(1, 1).gather(Gatherers4j.ensureOrdered(Order.Descending)).toList()
-                    ).withMessage("Elements not in proper order: Descending");
+                    )
+                    .withMessage("Elements not in proper order: Descending");
             }
 
             @Test

--- a/src/test/java/com/ginsberg/gatherers4j/InterleavingGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/InterleavingGathererTest.java
@@ -16,15 +16,15 @@
 
 package com.ginsberg.gatherers4j;
 
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import static com.ginsberg.gatherers4j.Gatherers4j.interleaveWith;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 class InterleavingGathererTest {
 
@@ -33,10 +33,9 @@ class InterleavingGathererTest {
 
         @Test
         void argumentIterableMustNotBeNull() {
-            assertThatThrownBy(() -> Stream.of("A")
-                    .gather(Gatherers4j.interleaveWith((Iterable<String>) null))
-                    .toList()
-            ).isInstanceOf(IllegalArgumentException.class);
+            assertThatIllegalArgumentException()
+                .isThrownBy(() -> Gatherers4j.interleaveWith((Iterable<String>) null))
+                .withMessage("Other iterable must not be null");
         }
 
         @Test
@@ -62,10 +61,9 @@ class InterleavingGathererTest {
 
         @Test
         void argumentIteratorMustNotBeNull() {
-            assertThatThrownBy(() -> Stream.of("A")
-                    .gather(Gatherers4j.interleaveWith((Iterator<String>) null))
-                    .toList()
-            ).isInstanceOf(IllegalArgumentException.class);
+            assertThatIllegalArgumentException()
+                .isThrownBy(() -> interleaveWith((Iterator<String>) null))
+                .withMessage("Other iterable must not be null");
         }
 
         @Test
@@ -90,10 +88,9 @@ class InterleavingGathererTest {
     class FromStream {
         @Test
         void argumentStreamMustNotBeNull() {
-            assertThatThrownBy(() -> Stream.of("A")
-                    .gather(Gatherers4j.interleaveWith((Stream<String>) null))
-                    .toList()
-            ).isInstanceOf(IllegalArgumentException.class);
+            assertThatIllegalArgumentException()
+                .isThrownBy(() -> interleaveWith((Stream<String>) null))
+                .withMessage("Other stream must not be null");
         }
 
         @Test
@@ -195,10 +192,9 @@ class InterleavingGathererTest {
 
         @Test
         void argumentMustNotBeNull() {
-            assertThatThrownBy(() -> Stream.of("A")
-                    .gather(Gatherers4j.interleaveWith((String[]) null))
-                    .toList()
-            ).isInstanceOf(IllegalArgumentException.class);
+            assertThatIllegalArgumentException()
+                .isThrownBy(() -> interleaveWith((String[]) null))
+                .withMessage("Other stream must not be null");
         }
 
         @Test

--- a/src/test/java/com/ginsberg/gatherers4j/SizeGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/SizeGathererTest.java
@@ -85,7 +85,8 @@ class SizeGathererTest {
             assertThatIllegalStateException()
                 .isThrownBy(() ->
                     Stream.of("A", "B", "C").gather(Gatherers4j.ensureSize(Size.Equals, 2)).toList()
-                ).withMessage("Invalid stream size: wanted Equals 2");
+                )
+                .withMessage("Invalid stream size: wanted Equals 2");
         }
 
         @Test
@@ -93,7 +94,8 @@ class SizeGathererTest {
             assertThatIllegalStateException()
                 .isThrownBy(() ->
                     Stream.of("A").gather(Gatherers4j.ensureSize(Size.Equals, 2)).toList()
-                ).withMessage(  "Invalid stream size: wanted Equals 2");
+                )
+                .withMessage(  "Invalid stream size: wanted Equals 2");
         }
 
         @Test
@@ -117,7 +119,8 @@ class SizeGathererTest {
             assertThatIllegalStateException()
                 .isThrownBy(() ->
                     Stream.of("A", "B").gather(Gatherers4j.ensureSize(Size.GreaterThan, 2)).toList()
-                ).withMessage(  "Invalid stream size: wanted GreaterThan 2");
+                )
+                .withMessage(  "Invalid stream size: wanted GreaterThan 2");
         }
 
         @Test
@@ -126,7 +129,8 @@ class SizeGathererTest {
                 .isThrownBy(() ->
                     Stream.of("A").gather(Gatherers4j.ensureSize(Size.GreaterThan, 2))
                         .toList()
-                ).withMessage("Invalid stream size: wanted GreaterThan 2");
+                )
+                .withMessage("Invalid stream size: wanted GreaterThan 2");
         }
 
         @Test
@@ -151,7 +155,8 @@ class SizeGathererTest {
                 .isThrownBy(() ->
                     Stream.of("A").gather(Gatherers4j.ensureSize(Size.GreaterThanOrEqualTo, 2))
                         .toList()
-                ).withMessage("Invalid stream size: wanted GreaterThanOrEqualTo 2");
+                )
+                .withMessage("Invalid stream size: wanted GreaterThanOrEqualTo 2");
         }
 
         @Test
@@ -225,7 +230,8 @@ class SizeGathererTest {
                 .isThrownBy(() ->
                     Stream.of("A", "B", "C")
                         .gather(Gatherers4j.ensureSize(Size.LessThanOrEqualTo, 2)).toList()
-                ).withMessage("Invalid stream size: wanted LessThanOrEqualTo 2");
+                )
+                .withMessage("Invalid stream size: wanted LessThanOrEqualTo 2");
         }
 
         @Test

--- a/src/test/java/com/ginsberg/gatherers4j/SizeGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/SizeGathererTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SizeGathererTest {
@@ -62,16 +64,16 @@ class SizeGathererTest {
         @Test
         void orElseMustNotBeNull() {
             //noinspection DataFlowIssue
-            assertThatThrownBy(() ->
-                    Stream.empty().gather(Gatherers4j.ensureSize(Size.Equals, 2).orElse(null)).toList()
-            ).isInstanceOf(IllegalArgumentException.class);
+            assertThatIllegalArgumentException()
+                .isThrownBy(() -> Gatherers4j.ensureSize(Size.Equals, 2).orElse(null))
+                .withMessage("The orElse function must not be null");
         }
 
         @Test
         void targetSizeMustNotBeNegative() {
-            assertThatThrownBy(() ->
-                    Stream.empty().gather(Gatherers4j.ensureSize(Size.Equals, -1)).toList()
-            ).isInstanceOf(IllegalArgumentException.class);
+            assertThatIllegalArgumentException()
+                .isThrownBy(() -> Gatherers4j.ensureSize(Size.Equals, -1))
+                .withMessage("Target size cannot be negative");
         }
     }
 
@@ -80,16 +82,18 @@ class SizeGathererTest {
 
         @Test
         void doesNotEmitOverTarget() {
-            assertThatThrownBy(() ->
+            assertThatIllegalStateException()
+                .isThrownBy(() ->
                     Stream.of("A", "B", "C").gather(Gatherers4j.ensureSize(Size.Equals, 2)).toList()
-            ).isInstanceOf(IllegalStateException.class);
+                ).withMessage("Invalid stream size: wanted Equals 2");
         }
 
         @Test
         void doesNotEmitUnderTarget() {
-            assertThatThrownBy(() ->
+            assertThatIllegalStateException()
+                .isThrownBy(() ->
                     Stream.of("A").gather(Gatherers4j.ensureSize(Size.Equals, 2)).toList()
-            ).isInstanceOf(IllegalStateException.class);
+                ).withMessage(  "Invalid stream size: wanted Equals 2");
         }
 
         @Test
@@ -110,16 +114,19 @@ class SizeGathererTest {
 
         @Test
         void doesNotEmitAtTarget() {
-            assertThatThrownBy(() ->
+            assertThatIllegalStateException()
+                .isThrownBy(() ->
                     Stream.of("A", "B").gather(Gatherers4j.ensureSize(Size.GreaterThan, 2)).toList()
-            ).isInstanceOf(IllegalStateException.class);
+                ).withMessage(  "Invalid stream size: wanted GreaterThan 2");
         }
 
         @Test
         void doesNotEmitUnderTarget() {
-            assertThatThrownBy(() ->
-                    Stream.of("A").gather(Gatherers4j.ensureSize(Size.GreaterThan, 2)).toList()
-            ).isInstanceOf(IllegalStateException.class);
+            assertThatIllegalStateException()
+                .isThrownBy(() ->
+                    Stream.of("A").gather(Gatherers4j.ensureSize(Size.GreaterThan, 2))
+                        .toList()
+                ).withMessage("Invalid stream size: wanted GreaterThan 2");
         }
 
         @Test
@@ -140,9 +147,11 @@ class SizeGathererTest {
 
         @Test
         void doesNotEmitUnderTarget() {
-            assertThatThrownBy(() ->
-                    Stream.of("A").gather(Gatherers4j.ensureSize(Size.GreaterThanOrEqualTo, 2)).toList()
-            ).isInstanceOf(IllegalStateException.class);
+            assertThatIllegalStateException()
+                .isThrownBy(() ->
+                    Stream.of("A").gather(Gatherers4j.ensureSize(Size.GreaterThanOrEqualTo, 2))
+                        .toList()
+                ).withMessage("Invalid stream size: wanted GreaterThanOrEqualTo 2");
         }
 
         @Test
@@ -176,16 +185,21 @@ class SizeGathererTest {
 
         @Test
         void doesNotEmitAtTarget() {
-            assertThatThrownBy(() ->
-                    Stream.of("A", "B").gather(Gatherers4j.ensureSize(Size.LessThan,  2)).toList()
-            ).isInstanceOf(IllegalStateException.class);
+            assertThatIllegalStateException()
+                .isThrownBy(() ->
+                    Stream.of("A", "B").gather(Gatherers4j.ensureSize(Size.LessThan, 2)).toList()
+                )
+                .withMessage("Invalid stream size: wanted LessThan 2");
         }
 
         @Test
         void doesNotEmitOverTarget() {
-            assertThatThrownBy(() ->
-                    Stream.of("A", "B", "C").gather(Gatherers4j.ensureSize(Size.LessThan,  2)).toList()
-            ).isInstanceOf(IllegalStateException.class);
+            assertThatIllegalStateException()
+                .isThrownBy(() ->
+                    Stream.of("A", "B", "C").gather(Gatherers4j.ensureSize(Size.LessThan, 2))
+                        .toList()
+                )
+                .withMessage("Invalid stream size: wanted LessThan 2");
         }
 
         @Test
@@ -207,9 +221,11 @@ class SizeGathererTest {
 
         @Test
         void doesNotEmitOverTarget() {
-            assertThatThrownBy(() ->
-                    Stream.of("A", "B", "C").gather(Gatherers4j.ensureSize(Size.LessThanOrEqualTo,  2)).toList()
-            ).isInstanceOf(IllegalStateException.class);
+            assertThatIllegalStateException()
+                .isThrownBy(() ->
+                    Stream.of("A", "B", "C")
+                        .gather(Gatherers4j.ensureSize(Size.LessThanOrEqualTo, 2)).toList()
+                ).withMessage("Invalid stream size: wanted LessThanOrEqualTo 2");
         }
 
         @Test

--- a/src/test/java/com/ginsberg/gatherers4j/TakeUntilGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/TakeUntilGathererTest.java
@@ -21,15 +21,18 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static com.ginsberg.gatherers4j.Gatherers4j.takeUntil;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 class TakeUntilGathererTest {
 
     @Test
     @SuppressWarnings("DataFlowIssue")
     void predicateMustNotBeNull() {
-        assertThatThrownBy(() -> Gatherers4j.takeUntil(null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> takeUntil(null))
+            .withMessage("Predicate must not be null");
     }
 
     @Test

--- a/src/test/java/com/ginsberg/gatherers4j/TypeFilteringGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/TypeFilteringGathererTest.java
@@ -16,13 +16,12 @@
 
 package com.ginsberg.gatherers4j;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import java.util.List;
 import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.Test;
 
 
 class TypeFilteringGathererTest {
@@ -50,8 +49,8 @@ class TypeFilteringGathererTest {
 
     @Test
     void mustHaveAtLeastOneValidType() {
-        assertThatThrownBy(TypeFilteringGatherer::of)
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThatIllegalArgumentException()
+            .isThrownBy(TypeFilteringGatherer::of);
     }
 
     @Test
@@ -73,9 +72,9 @@ class TypeFilteringGathererTest {
     @SuppressWarnings("DataFlowIssue")
     @Test
     void validTypesMustNotBeNull() {
-        assertThatThrownBy(() -> {
-            TypeFilteringGatherer.of((Class<Object>[])null);
-        }).isInstanceOf(IllegalArgumentException.class);
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> TypeFilteringGatherer.of((Class<Object>[]) null))
+            .withMessage("validTypes must not be null");
     }
 
 }

--- a/src/test/java/com/ginsberg/gatherers4j/WindowGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/WindowGathererTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 class WindowGathererTest {
 
@@ -83,15 +83,17 @@ class WindowGathererTest {
     @ParameterizedTest
     @ValueSource(ints = {-1, 0})
     void steppingMustBePositive(int stepping) {
-        assertThatThrownBy(() -> new WindowGatherer<>(1, stepping, true))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> new WindowGatherer<>(1, stepping, true))
+            .withMessage("Stepping must be greater than zero");
     }
 
     @ParameterizedTest
     @ValueSource(ints = {-1, 0})
     void windowSizeMustBePositive(int windowSize) {
-        assertThatThrownBy(() -> new WindowGatherer<>(windowSize, 1, true))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> new WindowGatherer<>(windowSize, 1, true))
+            .withMessage("Window size must be greater than zero");
     }
 
     @Test

--- a/src/test/java/com/ginsberg/gatherers4j/ZipWithGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/ZipWithGathererTest.java
@@ -24,50 +24,52 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 class ZipWithGathererTest {
 
     @Test
     void argumentIterableMustNotBeNull() {
-        assertThatThrownBy(() -> Stream.of("A")
-                .gather(Gatherers4j.zipWith((Iterable<String>) null)).toList()
-        ).isInstanceOf(IllegalArgumentException.class);
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> Gatherers4j.zipWith((Iterable<String>) null))
+            .withMessage("Other iterable must not be null");
     }
 
     @Test
     void argumentIteratorMustNotBeNull() {
-        assertThatThrownBy(() -> Stream.of("A")
-                .gather(Gatherers4j.zipWith((Iterator<String>) null)).toList()
-        ).isInstanceOf(IllegalArgumentException.class);
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> Gatherers4j.zipWith((Iterator<String>) null))
+            .withMessage("Other iterator must not be null");
     }
 
     @Test
     void argumentStreamMustNotBeNull() {
-        assertThatThrownBy(() -> Stream.of("A")
-                .gather(Gatherers4j.zipWith((Stream<String>) null)).toList()
-        ).isInstanceOf(IllegalArgumentException.class);
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> Gatherers4j.zipWith((Stream<String>) null))
+            .withMessage("Other stream must not be null");
     }
 
     @Test
     void argumentVarargsMustNotBeNull() {
-        assertThatThrownBy(() -> Stream.of("A")
-                .gather(Gatherers4j.zipWith((String[]) null)).toList()
-        ).isInstanceOf(IllegalArgumentException.class);
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> Gatherers4j.zipWith((String[]) null))
+            .withMessage("Other stream must not be null");
     }
 
     @Test
     void argumentWhenSourceLongerFunctionMustNotBeNull() {
-        assertThatThrownBy(() -> Stream.of("A")
-                .gather(Gatherers4j.zipWith(List.of("A")).argumentWhenSourceLonger(null)).toList()
-        ).isInstanceOf(IllegalArgumentException.class);
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> Gatherers4j.zipWith(List.of("A")).argumentWhenSourceLonger(null))
+            .withMessage(
+                "Mapping function must not be null, use nullArgumentWhenSourceLonger() to insert nulls");
     }
 
     @Test
     void sourceWhenArgumentLongerFunctionMustNotBeNull() {
-        assertThatThrownBy(() -> Stream.of("A")
-                .gather(Gatherers4j.zipWith(List.of("A")).sourceWhenArgumentLonger(null)).toList()
-        ).isInstanceOf(IllegalArgumentException.class);
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> Gatherers4j.zipWith(List.of("A")).sourceWhenArgumentLonger(null))
+            .withMessage(
+                "Mapping function must not be null, use nullSourceWhenArgumentLonger() to insert nulls");
     }
 
 


### PR DESCRIPTION
- replace use of `assertThatThrownBy` with `assertThatIllegalArgumentException` respectively `assertThatIllegalStateException`
- reduce the scope of the lambda to the minimum (removing irrelevant object creations for the scope of the test, like `Stream.of`)
- add assertion for the exception message

Fixes #182 