### PR TITLE
Upgrade dependencies and Gradle wrapper

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Todd Ginsberg
+ * Copyright 2024-2026 Todd Ginsberg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ plugins {
     id("org.jreleaser") version "1.22.0"
     id("maven-publish")
     id("me.champeau.jmh") version "0.7.3"
-    id("net.ltgt.errorprone") version "4.3.0"
+    id("net.ltgt.errorprone") version "4.4.0"
     id("signing")
 }
 
@@ -33,7 +33,7 @@ description = "An extra set of helpful Stream Gatherers for Java"
 group = "com.ginsberg"
 version = file("VERSION.txt").readLines().first()
 
-val jUnitVersion = "6.0.1"
+val jUnitVersion = "6.0.2"
 
 val gitBranch = gitBranch()
 val gatherers4jVersion = if (gitBranch == "main" || gitBranch.startsWith("release/")) version.toString()
@@ -66,14 +66,14 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:$jUnitVersion") {
         because("We need this to run tests")
     }
-    testImplementation("org.assertj:assertj-core:3.27.6") {
+    testImplementation("org.assertj:assertj-core:3.27.7") {
         because("These assertions are clearer than JUnit+Hamcrest")
     }
 
-    errorprone("com.google.errorprone:error_prone_core:2.45.0") {
+    errorprone("com.google.errorprone:error_prone_core:2.46.0") {
         because("This helps us eliminate bugs during the development cycle")
     }
-    errorprone("com.uber.nullaway:nullaway:0.12.15") {
+    errorprone("com.uber.nullaway:nullaway:0.13.0") {
         because("It helps us find nullability issues, along with JSpecify")
     }
 }
@@ -91,7 +91,6 @@ jreleaser {
 
     signing {
         active.set(org.jreleaser.model.Active.NEVER)
-        armored.set(true)
     }
 
     deploy {
@@ -101,7 +100,6 @@ jreleaser {
                     active.set(org.jreleaser.model.Active.RELEASE)
                     url = "https://central.sonatype.com/api/v1/publisher"
                     stagingRepository("build/staging-deploy")
-                    sign = false
                     applyMavenCentralRules = true
                 }
             }
@@ -110,7 +108,6 @@ jreleaser {
                     active.set(org.jreleaser.model.Active.SNAPSHOT)
                     snapshotUrl = "https://central.sonatype.com/repository/maven-snapshots"
                     url = "https://central.sonatype.com/repository/maven-snapshots"
-                    sign = false
                     applyMavenCentralRules = true
                     snapshotSupported = true
                     closeRepository = false
@@ -190,8 +187,9 @@ tasks {
     }
 
     jacoco {
-        toolVersion = "0.8.13"
+        toolVersion = "0.8.14"
     }
+
     jacocoTestReport {
         dependsOn(test)
         reports {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2024-2025 Todd Ginsberg
+# Copyright 2024-2026 Todd Ginsberg
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Upgrade Gradle from 9.2.1 to 9.3.0
- Upgrade net.ltgt.errorprone from 4.3.0 to 4.4.0
- Upgrade JUnit from 6.0.1 to 6.0.2
- Upgrade assertj-core from 3.27.6 to 3.27.7
- Upgrade error_prone_core from 2.45.0 to 2.46.0
- Upgrade nullaway from 0.12.15 to 0.13.0
- Upgrade JaCoCo from 0.8.13 to 0.8.14
- Remove unused signing configurations in JReleaser settings