### PR TITLE
Configure PITest for mutation testing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ import java.io.IOException
 
 plugins {
     id("com.adarshr.test-logger") version "4.0.0"
+    id("info.solidsoft.pitest") version "1.19.0-rc.3"
     id("jacoco")
     id("java-library")
     id("org.jreleaser") version "1.22.0"
@@ -118,6 +119,22 @@ jreleaser {
         }
 
     }
+}
+
+pitest {
+    coverageThreshold = 80
+    features = listOf("+auto_threads")
+    historyInputLocation = layout.buildDirectory.file("pitHistory").get().asFile
+    historyOutputLocation = layout.buildDirectory.file("pitHistory").get().asFile
+    junit5PluginVersion = "1.2.1"
+    mutationThreshold = 75
+    mutators = listOf("DEFAULTS")
+    outputFormats = listOf("HTML", "XML")
+    targetClasses = listOf("com.ginsberg.gatherers4j.*")
+    targetTests = listOf("com.ginsberg.gatherers4j.*")
+    threads = Runtime.getRuntime().availableProcessors()
+    timestampedReports = false
+    verbose = true
 }
 
 publishing {
@@ -224,6 +241,7 @@ tasks {
     }
 
 }
+
 
 fun gitBranch(): String =
     ProcessBuilder("git rev-parse --abbrev-ref HEAD".split(" "))

--- a/src/main/java/com/ginsberg/gatherers4j/BigDecimalGeometricMeanGatherer.java
+++ b/src/main/java/com/ginsberg/gatherers4j/BigDecimalGeometricMeanGatherer.java
@@ -54,9 +54,6 @@ public final class BigDecimalGeometricMeanGatherer<INPUT extends @Nullable Objec
 
         @Override
         public BigDecimal calculate() {
-            if (count == 0) {
-                return BigDecimal.ZERO;
-            }
             return MathUtils.nthRoot(product, count, mathContext);
         }
     }

--- a/src/main/java/com/ginsberg/gatherers4j/util/MathUtils.java
+++ b/src/main/java/com/ginsberg/gatherers4j/util/MathUtils.java
@@ -103,7 +103,12 @@ public abstract class MathUtils {
      * @return the result of base^exponent
      */
     public static BigDecimal pow(final BigDecimal base, final long exponent, final MathContext mc) {
-        if (exponent == 0) {
+        mustNotBeNull(base, "Base cannot be null");
+        mustNotBeNull(mc, "MathContext cannot be null");
+
+        if (exponent < 0) {
+            throw new IllegalArgumentException("Exponent must be non-negative");
+        } else if (exponent == 0) {
             return BigDecimal.ONE;
         } else if (exponent == 1) {
             return base;

--- a/src/test/java/com/ginsberg/gatherers4j/RotateGathererTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/RotateGathererTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Todd Ginsberg
+ * Copyright 2024-2026 Todd Ginsberg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,18 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class RotateGathererTest {
+
+    @Nested
+    class RotateEnum {
+        @Test
+        void leftFlipsToRight() {
+            assertThat(Rotate.Left.flip()).isEqualTo(Rotate.Right);
+        }
+        @Test
+        void rightFlipsToLeft() {
+            assertThat(Rotate.Right.flip()).isEqualTo(Rotate.Left);
+        }
+    }
 
     @Nested
     class RotateLeft {

--- a/src/test/java/com/ginsberg/gatherers4j/SimpleIndexingGatherersTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/SimpleIndexingGatherersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Todd Ginsberg
+ * Copyright 2024-2026 Todd Ginsberg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,24 @@ class SimpleIndexingGatherersTest {
 
             // Assert
             assertThat(output).containsExactly("A", "C", "D");
+        }
+
+        @Test
+        void filteringIncrementsIndex() {
+            // Arrange
+            final Stream<String> input = Stream.of("A", "B", "C", "D");
+            final List<Integer> indices = new ArrayList<>();
+
+            // Act
+            final List<String> output = input
+                    .gather(Gatherers4j.filterIndexed((index, _) -> {
+                                indices.add(index);
+                                return index % 2 == 0;
+                            }
+                    )).toList();
+
+            assertThat(output).containsExactly("A", "C");
+            assertThat(indices).containsExactly(0, 1, 2, 3);
         }
 
         @SuppressWarnings("DataFlowIssue")

--- a/src/test/java/com/ginsberg/gatherers4j/util/MathUtilsTest.java
+++ b/src/test/java/com/ginsberg/gatherers4j/util/MathUtilsTest.java
@@ -18,17 +18,26 @@ package com.ginsberg.gatherers4j.util;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class MathUtilsTest {
 
     @Nested
     class NthRoot {
+        @Test
+        void firstRootReturnsSelf() {
+            assertThat(MathUtils.nthRoot(new BigDecimal("16"), 1))
+                    .isEqualByComparingTo("16");
+        }
+
         @Test
         void squareRoot() {
             assertThat(MathUtils.nthRoot(new BigDecimal("16"), 2))
@@ -78,6 +87,47 @@ class MathUtilsTest {
             assertThat(MathUtils.nthRoot(BigDecimal.ONE, n))
                     .isEqualByComparingTo("1");
         }
+
+        @ParameterizedTest(name = "root is {0}")
+        @ValueSource(ints = {-1, 0 } )
+        void invalidRoots(int root) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> MathUtils.nthRoot(BigDecimal.ONE, root));
+        }
+
+        @SuppressWarnings("DataFlowIssue")
+        @Test
+        void missingValue() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> MathUtils.nthRoot(null, 2));
+        }
+
+        @SuppressWarnings("DataFlowIssue")
+        @Test
+        void missingMathContext() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> MathUtils.nthRoot(BigDecimal.ONE, 2, null));
+        }
+
+        @Test
+        void verySmallPositiveValue() {
+            assertThat(MathUtils.nthRoot(new BigDecimal("0.00000001"), 2))
+                    .isEqualByComparingTo("0.0001");
+        }
+
+        @ParameterizedTest(name = "root {0} of ONE returns ONE")
+        @ValueSource(longs = {1, 2, 3, 5, 10, 100, 1000})
+        void rootOfOneReturnsOne(long root) {
+            assertThat(MathUtils.nthRoot(BigDecimal.ONE, root))
+                    .isEqualByComparingTo("1");
+        }
+
+        @Test
+        void zeroPrecisionMathContext() {
+            final MathContext mc = new MathContext(0);
+            final BigDecimal result = MathUtils.nthRoot(new BigDecimal("100"), 2, mc);
+            assertThat(result).isEqualByComparingTo("10");
+        }
     }
 
     @Nested
@@ -98,6 +148,87 @@ class MathUtilsTest {
         void positiveExponent() {
             assertThat(MathUtils.pow(new BigDecimal("2"), 10, MathContext.DECIMAL64))
                     .isEqualByComparingTo("1024");
+        }
+
+        @Test
+        void negativeExponent() {
+            // Should throw or have defined behavior - let's see what happens
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> MathUtils.pow(new BigDecimal("2"), -5, MathContext.DECIMAL64));
+        }
+
+        @Test
+        void exponentTwo() {
+            assertThat(MathUtils.pow(new BigDecimal("7"), 2, MathContext.DECIMAL64))
+                    .isEqualByComparingTo("49");
+        }
+
+        @Test
+        void oddExponentFive() {
+            assertThat(MathUtils.pow(new BigDecimal("3"), 5, MathContext.DECIMAL64))
+                    .isEqualByComparingTo("243");
+        }
+
+        @Test
+        void oddExponentSeven() {
+            assertThat(MathUtils.pow(new BigDecimal("2"), 7, MathContext.DECIMAL64))
+                    .isEqualByComparingTo("128");
+        }
+
+        @Test
+        void largeEvenExponent() {
+            assertThat(MathUtils.pow(new BigDecimal("2"), 16, MathContext.DECIMAL64))
+                    .isEqualByComparingTo("65536");
+        }
+
+        @Test
+        void largeEvenExponentThirtyTwo() {
+            assertThat(MathUtils.pow(new BigDecimal("2"), 32, MathContext.DECIMAL64))
+                    .isEqualByComparingTo("4294967296");
+        }
+
+        @Test
+        void zeroBaseWithZeroExponent() {
+            assertThat(MathUtils.pow(BigDecimal.ZERO, 0, MathContext.DECIMAL64))
+                    .isEqualByComparingTo("1");
+        }
+
+        @Test
+        void zeroBaseWithPositiveExponent() {
+            assertThat(MathUtils.pow(BigDecimal.ZERO, 5, MathContext.DECIMAL64))
+                    .isEqualByComparingTo("0");
+        }
+
+        @ParameterizedTest(name = "exponent {0} of ONE returns ONE")
+        @ValueSource(ints = {0, 1, 100})
+        void oneBaseWithVariousExponents(int exponent) {
+            assertThat(MathUtils.pow(BigDecimal.ONE, exponent, MathContext.DECIMAL64))
+                    .isEqualByComparingTo("1");
+        }
+        @Test
+        void negativeBase() {
+            assertThat(MathUtils.pow(new BigDecimal("-2"), 3, MathContext.DECIMAL64))
+                    .isEqualByComparingTo("-8");
+        }
+
+        @Test
+        void negativeBaseEvenExponent() {
+            assertThat(MathUtils.pow(new BigDecimal("-3"), 4, MathContext.DECIMAL64))
+                    .isEqualByComparingTo("81");
+        }
+
+        @SuppressWarnings("DataFlowIssue")
+        @Test
+        void nullBase() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> MathUtils.pow(null, 2, MathContext.DECIMAL64));
+        }
+
+        @SuppressWarnings("DataFlowIssue")
+        @Test
+        void nullMathContext() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> MathUtils.pow(new BigDecimal("2"), 2, null));
         }
     }
 }


### PR DESCRIPTION
+ Some fixes
+ Greedy Integrators often have false positives for mutation testing since the JDK can ignore the results. At some point I should test "passes downstream along" but that might be testing too close to the implementation details.