### PR TITLE
Support test against multiple JDKs, switch to Corretto

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'temurin'
+          distribution: 'corretto'
           cache: 'gradle'
 
       - name: Run JMH (all benchmarks)

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   jmh:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: ['25', '26']
     permissions:
       contents: read
       packages: write
@@ -22,10 +25,10 @@ jobs:
 
       - uses: gradle/actions/wrapper-validation@v4
 
-      - name: Set up JDK 25
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v5
         with:
-          java-version: '25'
+          java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
           cache: 'gradle'
 
@@ -41,7 +44,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: jmh-reports
+          name: jmh-reports-${{ matrix.java-version }}
           path: |
             build/results/jmh/**
           if-no-files-found: warn

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - uses: gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/wrapper-validation@v5
 
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v5

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,11 +34,11 @@ jobs:
 
       - name: Run JMH (all benchmarks)
         if: ${{ github.event.inputs.include == '' }}
-        run: ./gradlew jmh --no-daemon
+        run: ./gradlew jmh -PjavaVersion=${{ matrix.java-version }} --no-daemon
 
       - name: Run JMH (filtered)
         if: ${{ github.event.inputs.include != '' }}
-        run: ./gradlew jmh --no-daemon -Pjmh.include="${{ github.event.inputs.include }}"
+        run: ./gradlew jmh -PjavaVersion=${{ matrix.java-version }} --no-daemon -Pjmh.include="${{ github.event.inputs.include }}"
 
       - name: Upload JMH reports
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - uses: gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/wrapper-validation@v5
 
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           cache: 'gradle'
 
       - name: Build
-        run: ./gradlew build --no-daemon
+        run: ./gradlew build -PjavaVersion=${{ matrix.java-version }} --no-daemon
 
       - name: Add coverage to PR
         if: github.event_name == 'pull_request'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'temurin'
+          distribution: 'corretto'
           cache: 'gradle'
 
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: ['25', '26']
     permissions:
       contents: read
       packages: write
@@ -16,10 +19,10 @@ jobs:
 
       - uses: gradle/actions/wrapper-validation@v4
 
-      - name: Set up JDK 25
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v5
         with:
-          java-version: '25'
+          java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '25'
-          distribution: 'temurin'
+          distribution: 'corretto'
           cache: 'gradle'
 
       - name: Publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - uses: gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/wrapper-validation@v5
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ description = "An extra set of helpful Stream Gatherers for Java"
 group = "com.ginsberg"
 version = file("VERSION.txt").readLines().first()
 
+val javaVersion = findProperty("javaVersion")?.toString()?.toInt() ?: 25
 val jUnitVersion = "6.0.2"
 
 val gitBranch = gitBranch()
@@ -42,7 +43,7 @@ else "${gitBranch.substringAfterLast("/")}-SNAPSHOT"
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(javaVersion)
     }
     withJavadocJar()
     withSourcesJar()


### PR DESCRIPTION
- Run build & test vs. 25 (LTS) and 26. 
- Publish with 25 (LTS).
- Support benchmarks on 25 (LTS) and 26.
- Upgrade wrapper-validation from v4 to v5
- Switch from temurin to corretto (quicker release cycles)